### PR TITLE
refactor: remove Supabase references from package

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,9 +48,6 @@ jobs:
               elif [[ $line == packages/adapter-prisma* ]];
               then
                   pkg_array+=("adapter-prisma")
-              elif [[ $line == packages/adapter-supabase* ]];
-              then
-                  pkg_array+=("adapter-supabase")
               elif [[ $line == packages/adapter-kysely* ]];
               then
                   pkg_array+=("adapter-kysely")
@@ -119,9 +116,6 @@ jobs:
           fi
           if [[ $pkg_string == *"adapter-prisma"* ]]; then
             cd packages/adapter-prisma && eval "$build_cmd"
-          fi
-          if [[ $pkg_string == *"adapter-supabase"* ]]; then
-            cd packages/adapter-supabase && eval "$build_cmd"
           fi
           if [[ $pkg_string == *"adapter-kysely"* ]]; then
             cd packages/adapter-kysely && eval "$build_cmd"

--- a/documentation/collection/main/learn/start-here/getting-started.md
+++ b/documentation/collection/main/learn/start-here/getting-started.md
@@ -19,7 +19,6 @@ Follow the guides below to set up your database:
 
 - [Prisma](/learn/adapters/prisma) (MySQL, SQLite, PostgreSQL)
 - [Kysely](/learn/adapters/kysely) (PostgreSQL, MySQL, SQLite)
-- [Supabase](/learn/adapters/supabase)
 - [Mongoose](/learn/adapters/mongoose) (MongoDB).
 
 ## Framework integration

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/pilcrowOnPaper/lucia-auth",
-		"directory": "packages/adapter-supabase"
+		"url": "https://github.com/pilcrowOnPaper/lucia-auth"
 	},
 	"keywords": [],
 	"author": "",


### PR DESCRIPTION
As the Supabase adaptor has been dropped (#325), I thought that it might be a good idea to cleanup the rest of its references throughout the code base.
Feel free to suggest if I've missed something or if I removed something that might have been necessary. 