### PR TITLE
docs: fix small typo in nuxt install instructions

### DIFF
--- a/documentation/content/main/getting-started/$nuxt.md
+++ b/documentation/content/main/getting-started/$nuxt.md
@@ -110,7 +110,7 @@ export default defineNuxtConfig({
 });
 ```
 
-Optionally, instead of doing a side-effect import, add the `--experimental-global-webcrypto` flag when running `next`.
+Optionally, instead of doing a side-effect import, add the `--experimental-global-webcrypto` flag when running `nuxt`.
 
 ```json
 // package.json


### PR DESCRIPTION
Should refer to nuxt and not next.