### PR TITLE
Add options to `Auth.setSession()`

### DIFF
--- a/.auri/$9wdj2mkj.md
+++ b/.auri/$9wdj2mkj.md
@@ -1,0 +1,6 @@
+---
+package: "lucia"
+type: "minor"
+---
+
+Add `SessionCookieOptions` to `Auth.setSession()`

--- a/packages/lucia/src/auth/cookie.ts
+++ b/packages/lucia/src/auth/cookie.ts
@@ -17,6 +17,10 @@ export type SessionCookieConfiguration = {
 	expires?: boolean;
 };
 
+export type SessionCookieOptions = {
+	browserSessionOnly: boolean;
+};
+
 const defaultSessionCookieAttributes: SessionCookieAttributes = {
 	sameSite: "lax",
 	path: "/"
@@ -24,7 +28,10 @@ const defaultSessionCookieAttributes: SessionCookieAttributes = {
 
 export const createSessionCookie = (
 	session: Session | null,
-	options: { env: Env; cookie: SessionCookieConfiguration }
+	options: {
+		env: Env;
+		cookie: SessionCookieConfiguration;
+	} & SessionCookieOptions
 ): Cookie => {
 	let expires: number;
 	if (session === null) {
@@ -40,7 +47,7 @@ export const createSessionCookie = (
 		{
 			...(options.cookie.attributes ?? defaultSessionCookieAttributes),
 			httpOnly: true,
-			expires: new Date(expires),
+			...(options.browserSessionOnly && { expires: new Date(expires) }),
 			secure: options.env === "PROD"
 		}
 	);

--- a/packages/lucia/src/auth/index.ts
+++ b/packages/lucia/src/auth/index.ts
@@ -13,7 +13,11 @@ import { createAdapter } from "./adapter.js";
 import { createKeyId } from "./database.js";
 import { isAllowedOrigin, safeParseUrl } from "../utils/url.js";
 
-import type { Cookie, SessionCookieConfiguration } from "./cookie.js";
+import type {
+	Cookie,
+	SessionCookieConfiguration,
+	SessionCookieOptions
+} from "./cookie.js";
 import type { UserSchema, SessionSchema, KeySchema } from "./database.js";
 import type { Adapter, SessionAdapter, InitializeAdapter } from "./adapter.js";
 import type { CSRFProtectionConfiguration, Middleware } from "./request.js";
@@ -573,8 +577,12 @@ export class Auth<_Configuration extends Configuration = any> {
 		});
 	};
 
-	public createSessionCookie = (session: Session | null): Cookie => {
+	public createSessionCookie = (
+		session: Session | null,
+		options: SessionCookieOptions
+	): Cookie => {
 		return createSessionCookie(session, {
+			...options,
 			env: this.env,
 			cookie: this.sessionCookieConfig
 		});

--- a/packages/lucia/src/auth/request.ts
+++ b/packages/lucia/src/auth/request.ts
@@ -5,7 +5,7 @@ import { createHeadersFromObject } from "../utils/request.js";
 import { isAllowedOrigin, safeParseUrl } from "../utils/url.js";
 
 import type { Auth, Env, Session } from "./index.js";
-import { type Cookie, type SessionCookieOptions } from "./cookie.js";
+import type { Cookie, SessionCookieOptions } from "./cookie.js";
 
 export type LuciaRequest = {
 	method: string;

--- a/packages/lucia/src/auth/request.ts
+++ b/packages/lucia/src/auth/request.ts
@@ -5,7 +5,7 @@ import { createHeadersFromObject } from "../utils/request.js";
 import { isAllowedOrigin, safeParseUrl } from "../utils/url.js";
 
 import type { Auth, Env, Session } from "./index.js";
-import type { Cookie } from "./cookie.js";
+import { type Cookie, type SessionCookieOptions } from "./cookie.js";
 
 export type LuciaRequest = {
 	method: string;
@@ -91,11 +91,14 @@ export class AuthRequest<_Auth extends Auth = any> {
 	private storedSessionId: string | null;
 	private bearerToken: string | null;
 
-	public setSession = (session: Session | null) => {
+	public setSession = (
+		session: Session | null,
+		options?: SessionCookieOptions
+	) => {
 		const sessionId = session?.sessionId ?? null;
 		if (this.storedSessionId === sessionId) return;
 		this.validatePromise = null;
-		this.setSessionCookie(session);
+		this.setSessionCookie(session, options ?? { browserSessionOnly: false });
 	};
 
 	private maybeSetSession = (session: Session | null) => {
@@ -107,11 +110,16 @@ export class AuthRequest<_Auth extends Auth = any> {
 		}
 	};
 
-	private setSessionCookie = (session: Session | null) => {
+	private setSessionCookie = (
+		session: Session | null,
+		options: SessionCookieOptions
+	) => {
 		const sessionId = session?.sessionId ?? null;
 		if (this.storedSessionId === sessionId) return;
 		this.storedSessionId = sessionId;
-		this.requestContext.setCookie(this.auth.createSessionCookie(session));
+		this.requestContext.setCookie(
+			this.auth.createSessionCookie(session, options)
+		);
 		if (session) {
 			debug.request.notice("Session cookie stored", session.sessionId);
 		} else {


### PR DESCRIPTION
### Description

You can now set the cookie `expiry` to be Session only for the browser, meaning that when the browser closes, the cookie will be deleted.

### Future

This should be expandable by adding stuff to `SessionCookieOptions`.

### Problems

The session key will still be valid, as it cannot be invalidated when the browser is closed, so it is not very "secure."

### Example code

```ts
const session = await auth.createSession({
  userId: user.userId,
  attributes: {},
});

const authRequest = auth.handleRequest({
  req,
  res,
});

authRequest.setSession(session, {
  browserSessionOnly: true, // 👈 you can now specify if the cookie has Session expiration
});
```

Real world example: https://account.proton.me/login (If you don't want to save the session for some reason, you can uncheck the box.)