### PR TITLE
Update cookie.ts

### DIFF
--- a/packages/lucia/src/auth/cookie.ts
+++ b/packages/lucia/src/auth/cookie.ts
@@ -6,7 +6,7 @@ import type { CookieAttributes } from "../utils/cookie.js";
 export const DEFAULT_SESSION_COOKIE_NAME = "auth_session";
 
 type SessionCookieAttributes = {
-	sameSite?: "strict" | "lax";
+	sameSite?: "Strict" | "Lax" | "None";
 	path?: string;
 	domain?: string;
 };
@@ -18,7 +18,7 @@ export type SessionCookieConfiguration = {
 };
 
 const defaultSessionCookieAttributes: SessionCookieAttributes = {
-	sameSite: "lax",
+	sameSite: "Lax",
 	path: "/"
 };
 


### PR DESCRIPTION
This helps to align types returned by Lucia's methods (such as auth.createCookieSession()) with types expected by cookie helper functions of other tools such as Hono's setCookie function that expects possible values for sameSite attribute to start from capital letters just as prescribed by mdn materials on cookies