### PR TITLE
Update cookie.ts

### DIFF
--- a/packages/lucia/src/utils/cookie.ts
+++ b/packages/lucia/src/utils/cookie.ts
@@ -45,7 +45,7 @@ export type CookieAttributes = Partial<{
 	maxAge: number;
 	path: string;
 	priority: "low" | "medium" | "high";
-	sameSite: true | false | "lax" | "strict" | "none";
+	sameSite: "Lax" | "Strict" | "None";
 	secure: boolean;
 }>;
 


### PR DESCRIPTION
This also helps to align types exported by Lucia library with types expected by other tools that help to set cookies. Most of the times those tools do not expect 'true' or 'false' types for sameSite attribute, also they expect 'lax', 'none', 'strict' options to start from capital letter