### PR TITLE
Prisma adapter: Use camel case

### DIFF
--- a/.auri/$66aawjwx.md
+++ b/.auri/$66aawjwx.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/adapter-prisma" # package name
+type: "major" # "major", "minor", "patch"
+---
+
+Use `camelCase` columns

--- a/documentation/content/main/database-adapters/prisma.md
+++ b/documentation/content/main/database-adapters/prisma.md
@@ -83,7 +83,62 @@ You can add additional columns to the user model to store user attributes, and t
 model User {
   id           String    @id @unique
 
-  auth_session Session[]
+  session      Session[]
+  key          Key[]
+}
+
+model Session {
+  id            String @id @unique
+  userId        String
+  activeExpires BigInt
+  idleExpires   BigInt
+  user          User   @relation(references: [id], fields: [userId], onDelete: Cascade)
+
+  @@index([user_id])
+}
+
+model Key {
+  id             String  @id @unique
+  hashedPassword String?
+  userId         String
+  user           User    @relation(references: [id], fields: [userId], onDelete: Cascade)
+
+  @@index([user_id])
+}
+```
+
+## Legacy adapter
+
+With `@lucia-auth/adapter-prisma@4.0`, columns are `camelCase`. To continue using the old schema (`snake_case`), use `prisma_legacy()` adapter.
+
+```ts
+import { lucia } from "lucia";
+import { prisma_legacy } from "@lucia-auth/adapter-prisma";
+import { PrismaClient } from "@prisma/client";
+
+const client = new PrismaClient();
+
+const auth = lucia({
+	adapter: prisma(client)
+	// ...
+});
+
+// default values
+const auth = lucia({
+	adapter: prisma_legacy(client, {
+		user: "user", // model User {}
+		key: "key", // model Key {}
+		session: "session" // model Session {}
+	})
+	// ...
+});
+```
+
+```prisma
+model User {
+  id           String    @id @unique
+
+  session      Session[]
   key          Key[]
 }
 

--- a/documentation/content/reference/index.md
+++ b/documentation/content/reference/index.md
@@ -33,6 +33,7 @@ title: "Reference overview"
 ### `@lucia-auth/adapter-prisma`
 
 - [`prisma()`](/database-adapters/prisma)
+- [`prisma_legacy()`](/database-adapters/prisma#legacy-adapter)
 
 ### `@lucia-auth/adapter-sqlite`
 

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -13,6 +13,7 @@
 	"scripts": {
 		"build": "shx rm -rf ./dist/* && tsc",
 		"test": "tsx test/index.ts",
+		"test.legacy": "tsx test/legacy.ts",
 		"test-setup": "prisma db push",
 		"auri.build": "pnpm build"
 	},

--- a/packages/adapter-prisma/prisma/schema.prisma
+++ b/packages/adapter-prisma/prisma/schema.prisma
@@ -11,28 +11,28 @@ datasource db {
 }
 
 model User {
-  id           String    @id @unique
-  username     String    @unique
-  auth_session Session[]
-  auth_key     Key[]
+  id          String    @id @unique
+  username    String    @unique
+  authSession Session[]
+  authKey     Key[]
 }
 
 model Session {
-  id             String @id @unique
-  user_id        String
-  active_expires BigInt
-  idle_expires   BigInt
-  country        String
-  user           User   @relation(references: [id], fields: [user_id], onDelete: Cascade)
+  id            String @id @unique
+  userId        String
+  activeExpires BigInt
+  idleExpires   BigInt
+  country       String
+  user          User   @relation(references: [id], fields: [userId], onDelete: Cascade)
 
-  @@index([user_id])
+  @@index([userId])
 }
 
 model Key {
-  id              String  @id @unique
-  hashed_password String?
-  user_id         String
-  user            User    @relation(references: [id], fields: [user_id], onDelete: Cascade)
+  id             String  @id @unique
+  hashedPassword String?
+  userId         String
+  user           User    @relation(references: [id], fields: [userId], onDelete: Cascade)
 
-  @@index([user_id])
+  @@index([userId])
 }

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -1,1 +1,3 @@
+export { prismaAdapter as prisma_legacy } from "./legacy.js";
 export { prismaAdapter as prisma } from "./prisma.js";
+

--- a/packages/adapter-prisma/src/lucia.d.ts
+++ b/packages/adapter-prisma/src/lucia.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="lucia" />
 declare namespace Lucia {
-	type Auth = any;
-	type DatabaseUserAttributes = any;
-	type DatabaseSessionAttributes = any;
+	type Auth = import("lucia").Auth;
+	type DatabaseUserAttributes = {};
+	type DatabaseSessionAttributes = {};
 }

--- a/packages/adapter-prisma/test/legacy.ts
+++ b/packages/adapter-prisma/test/legacy.ts
@@ -1,0 +1,46 @@
+import { testAdapter, Database } from "@lucia-auth/adapter-test";
+import { LuciaError } from "lucia";
+import { PrismaClient } from "@prisma/client";
+
+import { prismaAdapter, transformPrismaSession } from "../src/legacy.js";
+
+import type { QueryHandler, TableQueryHandler } from "@lucia-auth/adapter-test";
+import type { TypedPrismaModel } from "../src/legacy.js";
+
+const client = new PrismaClient();
+
+const createTableQueryHandler = (model: any): TableQueryHandler => {
+	const Model = model as TypedPrismaModel;
+	return {
+		get: async () => {
+			return await Model.findMany();
+		},
+		insert: async (value: any) => {
+			await Model.create({
+				data: value
+			});
+		},
+		clear: async () => {
+			await Model.deleteMany();
+		}
+	};
+};
+
+const queryHandler: QueryHandler = {
+	user: createTableQueryHandler(client.user),
+	session: {
+		...createTableQueryHandler(client.session),
+		get: async () => {
+			const Session = client.session as any as TypedPrismaModel;
+			const result = await Session.findMany();
+			return result.map((val) => transformPrismaSession(val));
+		}
+	},
+	key: createTableQueryHandler(client.key)
+};
+
+const adapter = prismaAdapter(client)(LuciaError);
+
+await testAdapter(adapter, new Database(queryHandler));
+
+process.exit(0);


### PR DESCRIPTION
To align with Prisma's style guide, this PR changes the Prisma adapter to use `camelCase` column names. Since migrating isn't very smooth (Prisma migration doesn't support column name changes), the old adapter will still be provided as `prisma_legacy()`.