### PR TITLE
Fix broken link in mysql2 database adapter page

### DIFF
--- a/documentation/content/main/database-adapters/mysql2.md
+++ b/documentation/content/main/database-adapters/mysql2.md
@@ -3,7 +3,7 @@ title: "`mysql2` adapter"
 description: "Learn how to use mysql2 with Lucia"
 ---
 
-Adapter for [`mysql2`](https://github.com/sidorares/node-mysql) provided by the MySQL adapter package.
+Adapter for [`mysql2`](https://github.com/sidorares/node-mysql2) provided by the MySQL adapter package.
 
 ```ts
 import { mysql2 } from "@lucia-auth/adapter-mysql";


### PR DESCRIPTION
The link to the mysql2 github repo is broken, as it appears the 2 was left off at the end of the link. This change fixes the link.