### PR TITLE
feat: use prisma neasted create when creating a user and key

### DIFF
--- a/documentation/content/main/database-adapters/prisma.md
+++ b/documentation/content/main/database-adapters/prisma.md
@@ -84,7 +84,7 @@ model User {
   id           String    @id @unique
 
   auth_session Session[]
-  key          Key[]
+  keys         Key[]
 }
 
 model Session {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
 		"format:docs": "pnpm exec prettier --write documentation --plugin=prettier-plugin-astro",
 		"preinstall": "npx only-allow pnpm",
 		"auri.format": "pnpm format",
-		"auri.publish_setup": "pnpm publish-setup"
+		"auri.publish_setup": "pnpm publish-setup",
+		"build": "pnpm -r --parallel --filter='./packages/**' run build",
+		"dev": "pnpm -r --parallel --filter='./packages/**' run build --watch",
+		"test:adapter:prisma": "pnpm -C packages/adapter-prisma run test"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -12,8 +12,8 @@
 	],
 	"scripts": {
 		"build": "shx rm -rf ./dist/* && tsc",
-		"test": "tsx test/index.ts",
-		"test-setup": "prisma db push",
+		"test": "pnpm test-setup && tsx test/index.ts",
+		"test-setup": "prisma generate && prisma db push",
 		"auri.build": "pnpm build"
 	},
 	"keywords": [
@@ -44,8 +44,8 @@
 		"lucia": "^2.0.0"
 	},
 	"devDependencies": {
-		"lucia": "latest",
-		"@lucia-auth/adapter-test": "latest",
+		"lucia": "workspace:*",
+		"@lucia-auth/adapter-test": "workspace:*",
 		"@prisma/client": "^5.0.0",
 		"prisma": "^4.9.0",
 		"tsx": "^3.12.6"

--- a/packages/adapter-prisma/prisma/schema.prisma
+++ b/packages/adapter-prisma/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id           String    @id @unique
   username     String    @unique
   auth_session Session[]
-  auth_key     Key[]
+  key          Key[]
 }
 
 model Session {

--- a/packages/adapter-prisma/prisma/schema.prisma
+++ b/packages/adapter-prisma/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id           String    @id @unique
   username     String    @unique
   auth_session Session[]
-  key          Key[]
+  keys         Key[]
 }
 
 model Session {

--- a/packages/adapter-prisma/src/prisma.ts
+++ b/packages/adapter-prisma/src/prisma.ts
@@ -59,14 +59,12 @@ export const prismaAdapter = <_PrismaClient extends PrismaClient>(
 					return;
 				}
 				try {
-					await client.$transaction([
-						User.create({
-							data: user
-						}),
-						Key.create({
-							data: key
-						})
-					]);
+					User.create({
+						data: {
+							key: { create: [key] }
+							...user
+						}
+					}),
 				} catch (e) {
 					const error = e as Partial<PossiblePrismaError>;
 					if (error.code === "P2002" && error.message?.includes("`id`"))

--- a/packages/adapter-prisma/src/prisma.ts
+++ b/packages/adapter-prisma/src/prisma.ts
@@ -63,7 +63,7 @@ export const prismaAdapter = <_PrismaClient extends PrismaClient>(
 					const { user_id: _, ...keyData } = key;
 					await User.create({
 						data: {
-							key: { create: [keyData] },
+							keys: { create: [keyData] },
 							...user
 						}
 					});

--- a/packages/adapter-prisma/src/prisma.ts
+++ b/packages/adapter-prisma/src/prisma.ts
@@ -59,12 +59,14 @@ export const prismaAdapter = <_PrismaClient extends PrismaClient>(
 					return;
 				}
 				try {
-					User.create({
+					// Userid is taken care of by prisma automatically
+					const { user_id: _, ...keyData } = key;
+					await User.create({
 						data: {
-							key: { create: [key] }
+							key: { create: [keyData] },
 							...user
 						}
-					}),
+					});
 				} catch (e) {
 					const error = e as Partial<PossiblePrismaError>;
 					if (error.code === "P2002" && error.message?.includes("`id`"))


### PR DESCRIPTION
Prisma supports neasted creates for relations, see https://www.prisma.io/docs/concepts/components/prisma-schema/relations#create-a-record-and-nested-records. This let's it optimize the creation depending on what the database supports.

Currently untested, how do I run the test suite?