### PR TITLE
fix: error in astro-doc

### DIFF
--- a/documentation/content/guidebook/sign-in-with-username-and-password/$astro.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/$astro.md
@@ -275,7 +275,7 @@ if (Astro.request.method === "POST") {
 				password
 			);
 			const session = await auth.createSession({
-				userId: user.userId,
+				userId: key.userId,
 				attributes: {}
 			});
 			Astro.locals.auth.setSession(session); // set session cookie


### PR DESCRIPTION
`user` was a typo in the original example. It should be `key`, just like the stackblitz-example.