### PR TITLE
Adds Keycloak Provider

### DIFF
--- a/.auri/$4u4hf1ka.md
+++ b/.auri/$4u4hf1ka.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/oauth" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+Adds Keycloak Provider

--- a/.auri/$4u4hf1ka.md
+++ b/.auri/$4u4hf1ka.md
@@ -4,3 +4,4 @@ type: "minor" # "major", "minor", "patch"
 ---
 
 Adds Keycloak Provider
+Adds Keycloak Documentation

--- a/.auri/$4u4hf1ka.md
+++ b/.auri/$4u4hf1ka.md
@@ -4,4 +4,3 @@ type: "minor" # "major", "minor", "patch"
 ---
 
 Adds Keycloak Provider
-Adds Keycloak Documentation

--- a/documentation/content/oauth/providers/keycloak.md
+++ b/documentation/content/oauth/providers/keycloak.md
@@ -1,6 +1,5 @@
 ---
 title: "Keycloak OAuth provider"
-
 description: "Learn how to use the Keycloak OAuth provider"
 ---
 
@@ -19,18 +18,12 @@ const keycloakAuth = keycloak(auth, config);
 ```ts
 const keycloak: (
 	auth: Auth,
-
 	config: {
 		domain: string;
-
 		realm: string;
-
 		clientId: string;
-
 		clientSecret: string;
-
 		scope?: string[];
-
 		redirectUri?: string;
 	}
 ) => KeycloakProvider;
@@ -38,30 +31,20 @@ const keycloak: (
 
 ##### Parameters
 
-| name | type | description | optional |
-
-| --------------------- | ------------------------------------------ | ------------------------------ | :------: |
-
-| `auth` | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance | |
-
-| `config.domain` | `string` | Keycloak OAuth app client id (e.g. 'my.domain.com') | |
-
-| `config.realm` | `string` | Keycloak Realm of client | |
-
-| `config.clientId` | `string` | Keycloak OAuth app client id | |
-
-| `config.clientSecret` | `string` | Keycloak OAuth app client secret | |
-
-| `config.scope` | `string[]` | an array of scopes | ✓ |
-
-| `config.redirectUri` | `string` | an authorized redirect URI | ✓ |
+| name                  | type                                       | description                                         | optional |
+| --------------------- | ------------------------------------------ | --------------------------------------------------- | :------: |
+| `auth`                | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance                                      |          |
+| `config.domain`       | `string`                                   | Keycloak OAuth app client id (e.g. 'my.domain.com') |          |
+| `config.realm`        | `string`                                   | Keycloak Realm of client                            |          |
+| `config.clientId`     | `string`                                   | Keycloak OAuth app client id                        |          |
+| `config.clientSecret` | `string`                                   | Keycloak OAuth app client secret                    |          |
+| `config.scope`        | `string[]`                                 | an array of scopes                                  |    ✓     |
+| `config.redirectUri`  | `string`                                   | an authorized redirect URI                          |    ✓     |
 
 ##### Returns
 
-| type | description |
-
-| ----------------------------------- | --------------- |
-
+| type                                    | description       |
+| --------------------------------------- | ----------------- |
 | [`KeycloakProvider`](#keycloakprovider) | Keycloak provider |
 
 ## Interfaces
@@ -75,41 +58,30 @@ See [`OAuth2ProviderAuth`](/reference/oauth/interfaces/oauth2providerauth).
 
 interface KeycloakAuth<_Auth extends Auth> {
 	getAuthorizationUrl: () => Promise<readonly [url: URL, state: string]>;
-
 	validateCallback: (code: string) => Promise<KeycloakUserAuth<_Auth>>;
 }
 ```
 
-| type |
-
-| ----------------------------------- |
-
+| type                                    |
+| --------------------------------------- |
 | [`KeycloakUserAuth`](#keycloakuserauth) |
 
 ##### Generics
 
-| name | extends | default |
-
+| name    | extends                                    | default |
 | ------- | ------------------------------------------ | ------- |
-
-| `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) | `Auth` |
+| `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) | `Auth`  |
 
 ### `KeycloakTokens`
 
 ```ts
 type KeycloakTokens = {
 	accessToken: string;
-
 	accessTokenExpiresIn: number;
-
 	authTime: number;
-
 	issuedAtTime: number;
-
 	expirationTime: number;
-
 	refreshToken: string | null;
-
 	refreshTokenExpiresIn: number | null;
 };
 ```
@@ -119,47 +91,26 @@ type KeycloakTokens = {
 ```ts
 type KeycloakUser = {
 	exp: number;
-
 	iat: number;
-
 	auth_time: number;
-
 	jti: string;
-
 	iss: string;
-
 	aud: string;
-
 	sub: string;
-
 	typ: string;
-
 	azp: string;
-
 	session_state: string;
-
 	at_hash: string;
-
 	acr: string;
-
 	sid: string;
-
 	email_verified: boolean;
-
 	name: string;
-
 	preferred_username: string;
-
 	given_name: string;
-
 	locale: string;
-
 	family_name: string;
-
 	email: string;
-
 	picture: string;
-
 	user: any;
 };
 ```
@@ -185,27 +136,19 @@ Extends [`ProviderUserAuth`](/reference/oauth/interfaces/provideruserauth).
 ```ts
 interface KeycloakUserAuth<_Auth extends Auth> extends ProviderUserAuth<_Auth> {
 	keycloakUser: KeycloakUser;
-
 	keycloakTokens: KeycloakTokens;
-
 	keycloakRoles: KeycloakRoles;
 }
 ```
 
-| properties | type | description |
-
-| -------------- | ------------------------------- | ----------------- |
-
-| `keycloakUser` | [`KeycloakUser`](#keycloakuser) | Keycloak user |
-
-| `keycloakTokens` | [`KeycloakTokens`](#keycloaktokens) | Access tokens etc |
-
-| `keycloakRoles` | [`KeycloakRoles`](#keycloakroles) | Keycloak roles retrieved from OIDC Token |
+| properties       | type                                | description                              |
+| ---------------- | ----------------------------------- | ---------------------------------------- |
+| `keycloakUser`   | [`KeycloakUser`](#keycloakuser)     | Keycloak user                            |
+| `keycloakTokens` | [`KeycloakTokens`](#keycloaktokens) | Access tokens etc                        |
+| `keycloakRoles`  | [`KeycloakRoles`](#keycloakroles)   | Keycloak roles retrieved from OIDC Token |
 
 ##### Generics
 
-| name | extends |
-
+| name    | extends                                    |
 | ------- | ------------------------------------------ |
-
 | `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) |

--- a/documentation/content/oauth/providers/keycloak.md
+++ b/documentation/content/oauth/providers/keycloak.md
@@ -1,68 +1,42 @@
-
-
 ---
-
 title: "Keycloak OAuth provider"
 
 description: "Learn how to use the Keycloak OAuth provider"
-
 ---
-
-  
 
 OAuth integration for Keycloak. Refer to [Keycloak Documentation](https://www.keycloak.org/docs/latest/authorization_services/index.html) for getting the required credentials. Provider id is `keycloak`.
 
-  
-
 ```ts
+import { keycloak } from "@lucia-auth/oauth/providers";
 
-import { keycloak } from  "@lucia-auth/oauth/providers";
+import { auth } from "./lucia.js";
 
-import { auth } from  "./lucia.js";
-
-  
-
-const  keycloakAuth = keycloak(auth, config);
-
+const keycloakAuth = keycloak(auth, config);
 ```
-
-  
 
 ## `keycloak()`
 
-  
-
 ```ts
+const keycloak: (
+	auth: Auth,
 
-const  keycloak: (
+	config: {
+		domain: string;
 
-auth: Auth,
+		realm: string;
 
-config: {
+		clientId: string;
 
-domain: string;
+		clientSecret: string;
 
-realm: string;
+		scope?: string[];
 
-clientId: string;
-
-clientSecret: string;
-
-scope?: string[];
-
-redirectUri?: string;
-
-}
-
-) =>  KeycloakProvider;
-
+		redirectUri?: string;
+	}
+) => KeycloakProvider;
 ```
 
-  
-
 ##### Parameters
-
-  
 
 | name | type | description | optional |
 
@@ -82,11 +56,7 @@ redirectUri?: string;
 
 | `config.redirectUri` | `string` | an authorized redirect URI | ✓ |
 
-  
-
 ##### Returns
-
-  
 
 | type | description |
 
@@ -94,35 +64,21 @@ redirectUri?: string;
 
 | [`KeycloakProvider`](#keycloakprovider) | Keycloak provider |
 
-  
-
 ## Interfaces
-
-  
 
 ### `KeycloakAuth`
 
-  
-
 See [`OAuth2ProviderAuth`](/reference/oauth/interfaces/oauth2providerauth).
 
-  
-
 ```ts
-
 // implements OAuth2ProviderAuth<KeycloakAuth<_Auth>>
 
-interface  KeycloakAuth<_Auth  extends  Auth> {
+interface KeycloakAuth<_Auth extends Auth> {
+	getAuthorizationUrl: () => Promise<readonly [url: URL, state: string]>;
 
-getAuthorizationUrl: () =>  Promise<readonly [url: URL, state: string]>;
-
-validateCallback: (code: string) =>  Promise<KeycloakUserAuth<_Auth>>;
-
+	validateCallback: (code: string) => Promise<KeycloakUserAuth<_Auth>>;
 }
-
 ```
-
-  
 
 | type |
 
@@ -130,11 +86,7 @@ validateCallback: (code: string) =>  Promise<KeycloakUserAuth<_Auth>>;
 
 | [`KeycloakUserAuth`](#keycloakuserauth) |
 
-  
-
 ##### Generics
-
-  
 
 | name | extends | default |
 
@@ -142,139 +94,103 @@ validateCallback: (code: string) =>  Promise<KeycloakUserAuth<_Auth>>;
 
 | `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) | `Auth` |
 
-  
-
 ### `KeycloakTokens`
 
-  
-
 ```ts
+type KeycloakTokens = {
+	accessToken: string;
 
-type  KeycloakTokens = {
+	accessTokenExpiresIn: number;
 
-accessToken:  string;
+	authTime: number;
 
-accessTokenExpiresIn:  number;
+	idleAt: number;
 
-authTime:  number;
+	expiresAt: number;
 
-idleAt:  number;
+	refreshToken: string | null;
 
-expiresAt:  number;
-
-refreshToken:  string  |  null;
-
-refreshTokenExpiresIn:  number  |  null;
-
+	refreshTokenExpiresIn: number | null;
 };
-
 ```
-
-  
 
 ### `KeycloakUser`
 
-  
-
 ```ts
+type KeycloakUser = {
+	exp: number;
 
-type  KeycloakUser = {
+	iat: number;
 
-exp:  number;
+	auth_time: number;
 
-iat:  number;
+	jti: string;
 
-auth_time:  number;
+	iss: string;
 
-jti:  string;
+	aud: string;
 
-iss:  string;
+	sub: string;
 
-aud:  string;
+	typ: string;
 
-sub:  string;
+	azp: string;
 
-typ:  string;
+	session_state: string;
 
-azp:  string;
+	at_hash: string;
 
-session_state:  string;
+	acr: string;
 
-at_hash:  string;
+	sid: string;
 
-acr:  string;
+	email_verified: boolean;
 
-sid:  string;
+	name: string;
 
-email_verified:  boolean;
+	preferred_username: string;
 
-name:  string;
+	given_name: string;
 
-preferred_username:  string;
+	locale: string;
 
-given_name:  string;
+	family_name: string;
 
-locale:  string;
+	email: string;
 
-family_name:  string;
+	picture: string;
 
-email:  string;
-
-picture:  string;
-
-user:  any;
-
+	user: any;
 };
 ```
-
-  
 
 ### `KeycloakRole`
 
-  
-
 ```ts
+type KeycloakUser = PublicKeycloakUser | PrivateKeycloakUser;
 
-type  KeycloakUser = PublicKeycloakUser | PrivateKeycloakUser;
+type KeycloakRole = {
+	role_type: "realm" | "resource";
 
-  
+	client: null | string; // null if realm_access
 
-type  KeycloakRole= {
-
-role_type:  "realm"  |  "resource",
-
-client:  null  |  string, // null if realm_access
-
-role:  string
-
+	role: string;
 };
 ```
 
-  
-
 ### `KeycloakUserAuth`
-
-  
 
 Extends [`ProviderUserAuth`](/reference/oauth/interfaces/provideruserauth).
 
-  
-
 ```ts
+interface KeycloakUserAuth<_Auth extends Auth> extends ProviderUserAuth<_Auth> {
+	keycloakUser: KeycloakUser;
 
-interface  KeycloakUserAuth<_Auth  extends  Auth> extends  ProviderUserAuth<_Auth> {
+	keycloakTokens: KeycloakTokens;
 
-keycloakUser: KeycloakUser;
-
-keycloakTokens: KeycloakTokens;
-
-keycloakRoles: KeycloakRoles;
-
+	keycloakRoles: KeycloakRoles;
 }
-
 ```
-
-  
 
 | properties | type | description |
 
@@ -286,11 +202,7 @@ keycloakRoles: KeycloakRoles;
 
 | `keycloakRoles` | [`KeycloakRoles`](#keycloakroles) | Keycloak roles retrieved from OIDC Token |
 
-  
-
 ##### Generics
-
-  
 
 | name | extends |
 

--- a/documentation/content/oauth/providers/keycloak.md
+++ b/documentation/content/oauth/providers/keycloak.md
@@ -1,0 +1,299 @@
+
+
+---
+
+title: "Keycloak OAuth provider"
+
+description: "Learn how to use the Keycloak OAuth provider"
+
+---
+
+  
+
+OAuth integration for Keycloak. Refer to [Keycloak Documentation](https://www.keycloak.org/docs/latest/authorization_services/index.html) for getting the required credentials. Provider id is `keycloak`.
+
+  
+
+```ts
+
+import { keycloak } from  "@lucia-auth/oauth/providers";
+
+import { auth } from  "./lucia.js";
+
+  
+
+const  keycloakAuth = keycloak(auth, config);
+
+```
+
+  
+
+## `keycloak()`
+
+  
+
+```ts
+
+const  keycloak: (
+
+auth: Auth,
+
+config: {
+
+domain: string;
+
+realm: string;
+
+clientId: string;
+
+clientSecret: string;
+
+scope?: string[];
+
+redirectUri?: string;
+
+}
+
+) =>  KeycloakProvider;
+
+```
+
+  
+
+##### Parameters
+
+  
+
+| name | type | description | optional |
+
+| --------------------- | ------------------------------------------ | ------------------------------ | :------: |
+
+| `auth` | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance | |
+
+| `config.domain` | `string` | Keycloak OAuth app client id (e.g. 'my.domain.com') | |
+
+| `config.realm` | `string` | Keycloak Realm of client | |
+
+| `config.clientId` | `string` | Keycloak OAuth app client id | |
+
+| `config.clientSecret` | `string` | Keycloak OAuth app client secret | |
+
+| `config.scope` | `string[]` | an array of scopes | ✓ |
+
+| `config.redirectUri` | `string` | an authorized redirect URI | ✓ |
+
+  
+
+##### Returns
+
+  
+
+| type | description |
+
+| ----------------------------------- | --------------- |
+
+| [`KeycloakProvider`](#keycloakprovider) | Keycloak provider |
+
+  
+
+## Interfaces
+
+  
+
+### `KeycloakAuth`
+
+  
+
+See [`OAuth2ProviderAuth`](/reference/oauth/interfaces/oauth2providerauth).
+
+  
+
+```ts
+
+// implements OAuth2ProviderAuth<KeycloakAuth<_Auth>>
+
+interface  KeycloakAuth<_Auth  extends  Auth> {
+
+getAuthorizationUrl: () =>  Promise<readonly [url: URL, state: string]>;
+
+validateCallback: (code: string) =>  Promise<KeycloakUserAuth<_Auth>>;
+
+}
+
+```
+
+  
+
+| type |
+
+| ----------------------------------- |
+
+| [`KeycloakUserAuth`](#keycloakuserauth) |
+
+  
+
+##### Generics
+
+  
+
+| name | extends | default |
+
+| ------- | ------------------------------------------ | ------- |
+
+| `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) | `Auth` |
+
+  
+
+### `KeycloakTokens`
+
+  
+
+```ts
+
+type  KeycloakTokens = {
+
+accessToken:  string;
+
+accessTokenExpiresIn:  number;
+
+authTime:  number;
+
+idleAt:  number;
+
+expiresAt:  number;
+
+refreshToken:  string  |  null;
+
+refreshTokenExpiresIn:  number  |  null;
+
+};
+
+```
+
+  
+
+### `KeycloakUser`
+
+  
+
+```ts
+
+type  KeycloakUser = {
+
+exp:  number;
+
+iat:  number;
+
+auth_time:  number;
+
+jti:  string;
+
+iss:  string;
+
+aud:  string;
+
+sub:  string;
+
+typ:  string;
+
+azp:  string;
+
+session_state:  string;
+
+at_hash:  string;
+
+acr:  string;
+
+sid:  string;
+
+email_verified:  boolean;
+
+name:  string;
+
+preferred_username:  string;
+
+given_name:  string;
+
+locale:  string;
+
+family_name:  string;
+
+email:  string;
+
+picture:  string;
+
+user:  any;
+
+};
+```
+
+  
+
+### `KeycloakRole`
+
+  
+
+```ts
+
+type  KeycloakUser = PublicKeycloakUser | PrivateKeycloakUser;
+
+  
+
+type  KeycloakRole= {
+
+role_type:  "realm"  |  "resource",
+
+client:  null  |  string, // null if realm_access
+
+role:  string
+
+};
+```
+
+  
+
+### `KeycloakUserAuth`
+
+  
+
+Extends [`ProviderUserAuth`](/reference/oauth/interfaces/provideruserauth).
+
+  
+
+```ts
+
+interface  KeycloakUserAuth<_Auth  extends  Auth> extends  ProviderUserAuth<_Auth> {
+
+keycloakUser: KeycloakUser;
+
+keycloakTokens: KeycloakTokens;
+
+keycloakRoles: KeycloakRoles;
+
+}
+
+```
+
+  
+
+| properties | type | description |
+
+| -------------- | ------------------------------- | ----------------- |
+
+| `keycloakUser` | [`KeycloakUser`](#keycloakuser) | Keycloak user |
+
+| `keycloakTokens` | [`KeycloakTokens`](#keycloaktokens) | Access tokens etc |
+
+| `keycloakRoles` | [`KeycloakRoles`](#keycloakroles) | Keycloak roles retrieved from OIDC Token |
+
+  
+
+##### Generics
+
+  
+
+| name | extends |
+
+| ------- | ------------------------------------------ |
+
+| `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) |

--- a/documentation/content/oauth/providers/keycloak.md
+++ b/documentation/content/oauth/providers/keycloak.md
@@ -104,9 +104,9 @@ type KeycloakTokens = {
 
 	authTime: number;
 
-	idleAt: number;
+	issuedAtTime: number;
 
-	expiresAt: number;
+	expirationTime: number;
 
 	refreshToken: string | null;
 

--- a/documentation/content/oauth/providers/keycloak.md
+++ b/documentation/content/oauth/providers/keycloak.md
@@ -7,7 +7,6 @@ OAuth integration for Keycloak. Refer to [Keycloak Documentation](https://www.ke
 
 ```ts
 import { keycloak } from "@lucia-auth/oauth/providers";
-
 import { auth } from "./lucia.js";
 
 const keycloakAuth = keycloak(auth, config);

--- a/packages/oauth/src/core/oauth2.ts
+++ b/packages/oauth/src/core/oauth2.ts
@@ -155,55 +155,6 @@ export const generateState = () => {
 	return generateRandomString(43);
 };
 
-export const refreshOAuth2Tokens = async <_ResponseBody extends {}>(
-	url: string | URL,
-	options: {
-		clientId: string;
-		refreshToken: string;
-		clientPassword?: {
-			clientSecret: string;
-			authenticateWith: "client_secret" | "http_basic_auth";
-		};
-	}
-): Promise<_ResponseBody> => {
-	const body = new URLSearchParams({
-		client_id: options.clientId,
-		grant_type: "refresh_token",
-		refresh_token: options.refreshToken,
-	});
-	if (
-		options.clientPassword &&
-		options.clientPassword.authenticateWith === "client_secret"
-	) {
-		body.set("client_secret", options.clientPassword.clientSecret);
-	}
-
-	const headers = new Headers({
-		"Content-Type": "application/x-www-form-urlencoded"
-	});
-	if (
-		options.clientPassword &&
-		options.clientPassword.authenticateWith === "http_basic_auth"
-	) {
-		headers.set(
-			"Authorization",
-			authorizationHeader(
-				"basic",
-				encodeBase64(
-					`${options.clientId}:${options.clientPassword.clientSecret}`
-				)
-			)
-		);
-	}
-
-	const request = new Request(new URL(url), {
-		method: "POST",
-		headers,
-		body
-	});
-	return await handleRequest<_ResponseBody>(request);
-};
-
 // Generates code_challenge from code_verifier, as specified in RFC 7636.
 export const generatePKCECodeChallenge = async (
 	method: "S256",

--- a/packages/oauth/src/providers/index.ts
+++ b/packages/oauth/src/providers/index.ts
@@ -97,6 +97,15 @@ export type {
 	GoogleUserAuth
 } from "./google.js";
 
+export { keycloak } from "./keycloak.js";
+export type {
+	KeycloakAuth,
+	KeycloakTokens,
+	KeycloakUser,
+	KeycloakRole,
+	KeycloakUserAuth
+} from "./keycloak.js";
+
 export { lichess } from "./lichess.js";
 export type {
 	LichessAuth,

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -5,7 +5,6 @@ import {
 } from "../core/oauth2.js";
 import { ProviderUserAuth } from "../core/provider.js";
 import { decodeIdToken } from "../index.js";
-import { encodeBase64 } from "../utils/encode.js";
 import { handleRequest, authorizationHeader } from "../utils/request.js";
 
 import type { Auth } from "lucia";

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -105,8 +105,8 @@ export class KeycloakAuth<
 				accessToken: tokens.access_token,
 				accessTokenExpiresIn: tokens.expires_in,
 				authTime: tokenDecoded.auth_time,
-				idleAt: tokenDecoded.iat,
-				expiresAt: tokenDecoded.exp,
+				issuedAtTime: tokenDecoded.iat,
+				expirationTime: tokenDecoded.exp,
 				refreshToken: tokens.refresh_token,
 				refreshTokenExpiresIn: tokens.refresh_expires_in
 			};
@@ -115,8 +115,8 @@ export class KeycloakAuth<
 			accessToken: tokens.access_token,
 			accessTokenExpiresIn: tokens.expires_in,
 			authTime: tokenDecoded.auth_time,
-			idleAt: tokenDecoded.iat,
-			expiresAt: tokenDecoded.exp,
+			issuedAtTime: tokenDecoded.iat,
+			expirationTime: tokenDecoded.exp,
 			refreshToken: null,
 			refreshTokenExpiresIn: null
 		};
@@ -210,8 +210,8 @@ export type KeycloakTokens = {
 	accessToken: string;
 	accessTokenExpiresIn: number;
 	authTime: number;
-	idleAt: number;
-	expiresAt: number;
+	issuedAtTime: number;
+	expirationTime: number;
 	refreshToken: string | null;
 	refreshTokenExpiresIn: number | null;
 };

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -1,7 +1,6 @@
 import {
 	OAuth2ProviderAuthWithPKCE,
 	createOAuth2AuthorizationUrlWithPKCE,
-	refreshOAuth2Tokens,
 	validateOAuth2AuthorizationCode
 } from "../core/oauth2.js";
 import { ProviderUserAuth } from "../core/provider.js";
@@ -84,27 +83,6 @@ export class KeycloakAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuthW
 		);
 
 		return this.claimTokens(rawTokens)
-	};
-
-	public refreshTokens = async (
-		refreshToken: string
-	): Promise<KeycloakUserAuth<_Auth>> => {
-		const rawTokens = await refreshOAuth2Tokens<AccessTokenResponseBody>(
-			`https://${ this.config.domain }/realms/${ this.config.realm }/protocol/openid-connect/token`,
-			{
-				clientId: this.config.clientId,
-				refreshToken: refreshToken,
-				clientPassword: {
-					authenticateWith: "http_basic_auth",
-					clientSecret: this.config.clientSecret
-				}
-			}
-		);
-		const keycloakTokens = this.claimTokens(rawTokens)
-		
-		const keycloakUser = await getKeycloakUser(this.config.domain, this.config.realm, keycloakTokens.accessToken);
-		const keycloakRoles = getKeycloakRoles(keycloakTokens.accessToken)
-		return new KeycloakUserAuth(this.auth, keycloakUser, keycloakTokens, keycloakRoles);
 	};
 
 	private claimTokens = (tokens: AccessTokenResponseBody): KeycloakTokens => {
@@ -240,6 +218,7 @@ export type KeycloakUser = {
     name: string;
     preferred_username: string;
     given_name: string;
+	locale: string;
     family_name: string;
     email: string;
     picture: string;

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -1,0 +1,212 @@
+import {
+	OAuth2ProviderAuthWithPKCE,
+	createOAuth2AuthorizationUrlWithPKCE,
+	validateOAuth2AuthorizationCode
+} from "../core/oauth2.js";
+import { ProviderUserAuth } from "../core/provider.js";
+import { handleRequest, authorizationHeader } from "../utils/request.js";
+
+import type { Auth } from "lucia";
+
+type Config = {
+  clientId: string;
+  clientSecret: string;
+  scope?: string[];
+  redirectUri?: string;
+  authEndpoint: string;
+  tokenEndpoint: string;
+  userinfoEndpoint: string;
+};
+
+const PROVIDER_ID = "keycloak";
+
+export const keycloak = <_Auth extends Auth = Auth>(
+	auth: _Auth,
+	config: Config
+): KeycloakAuth<_Auth> => {
+	return new KeycloakAuth(auth, config);
+};
+
+export class KeycloakAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuthWithPKCE<
+	KeycloakUserAuth<_Auth>
+> {
+	private config: Config;
+
+	constructor(auth: _Auth, config: Config) {
+		super(auth);
+
+		this.config = config;
+	}
+
+	public getAuthorizationUrl = async (): Promise<
+		readonly [url: URL, codeVerifier: string, state: string]
+	> => {
+    const scopeConfig = this.config.scope ?? [];
+		return await createOAuth2AuthorizationUrlWithPKCE(
+			this.config.authEndpoint,
+			{
+        clientId: this.config.clientId,
+        scope: ["profile", "openid", ...scopeConfig],
+        redirectUri: this.config.redirectUri,
+        codeChallengeMethod: "S256"
+			}
+		);
+	};
+
+	public validateCallback = async (
+		code: string,
+    code_verifier: string
+	): Promise<KeycloakUserAuth<_Auth>> => {
+		const keycloakTokens = await this.validateAuthorizationCode(code, code_verifier);
+		const keycloakUser = await getKeycloakUser(this.config.userinfoEndpoint, keycloakTokens.accessToken);
+		const keycloakRoles = getKeycloakRoles(keycloakTokens.accessToken)
+		return new KeycloakUserAuth(this.auth, keycloakUser, keycloakTokens, keycloakRoles);
+	};
+
+	private validateAuthorizationCode = async (
+		code: string,
+    codeVerifier: string
+	): Promise<KeycloakTokens> => {
+		const tokens = await validateOAuth2AuthorizationCode<AccessTokenResponseBody>(
+			code,
+			this.config.tokenEndpoint,
+			{
+				clientId: this.config.clientId,
+				redirectUri: this.config.redirectUri,
+				codeVerifier,
+				clientPassword: {
+					authenticateWith: "http_basic_auth",
+					clientSecret: this.config.clientSecret
+				}
+			}
+		);
+		const tokenDecoded =  decodeIdToken<Claims>(tokens.access_token)
+
+		if ("refresh_token" in tokens) {
+			return {
+				accessToken: tokens.access_token,
+				accessTokenExpiresIn: tokens.expires_in,
+				authTime: tokenDecoded.auth_time,
+				idleAt: tokenDecoded.iat,
+				expiresAt: tokenDecoded.exp,
+				refreshToken: tokens.refresh_token,
+				refreshTokenExpiresIn: tokens.refresh_expires_in,
+			};
+		}
+		return {
+			accessToken: tokens.access_token,
+			accessTokenExpiresIn: tokens.expires_in,
+			authTime: tokenDecoded.auth_time,
+			idleAt: tokenDecoded.iat,
+			expiresAt: tokenDecoded.exp,
+			refreshToken: null,
+			refreshTokenExpiresIn: null,
+		};
+	};
+}
+
+const getKeycloakUser = async (userinfoEndpoint: string, accessToken: string): Promise<KeycloakUser> => {
+	const keycloakUserRequest = new Request(userinfoEndpoint, {
+		headers: {
+			Authorization: authorizationHeader("bearer", accessToken)
+		}
+	});
+	return await handleRequest<KeycloakUser>(keycloakUserRequest);
+};
+
+const getKeycloakRoles = (accessToken: string): KeycloakRole[] => {
+	const tokenDecoded: Claims =  decodeIdToken<Claims>(accessToken)
+	const keycloakRoles: KeycloakRole[] = []
+
+	if (tokenDecoded.hasOwnProperty('realm_access')) {
+		for (const role of tokenDecoded.realm_access.roles) {
+			keycloakRoles.push({
+				type: 'realm',
+				client: null,
+				role: role
+			})
+		}
+	}
+	if (tokenDecoded.hasOwnProperty('resource_access')) {
+		for (const [key, client] of Object.entries(tokenDecoded.resource_access)) {
+			for (const role of client.roles) {
+				keycloakRoles.push({
+					type: 'resource',
+					client: key,
+					role: role
+				})
+			}
+		}
+	}
+
+	return keycloakRoles
+}
+
+export class KeycloakUserAuth<
+	_Auth extends Auth
+> extends ProviderUserAuth<_Auth> {
+	public keycloakTokens: KeycloakTokens;
+	public keycloakUser: KeycloakUser;
+	public keycloakRoles: KeycloakRole[]
+
+	constructor(auth: _Auth, keycloakUser: KeycloakUser, keycloakTokens: KeycloakTokens, keycloakRoles: KeycloakRole[]) {
+		super(auth, PROVIDER_ID, keycloakUser.sub);
+
+		this.keycloakTokens = keycloakTokens;
+		this.keycloakUser = keycloakUser;
+		this.keycloakRoles = keycloakRoles;
+	}
+}
+
+type AccessTokenResponseBody =
+	| {
+			access_token: string;
+			expires_in: number;
+			auth_time: number;
+			idle_at: number;
+			expires_at: number;
+	  }
+	| {
+		access_token: string;
+		expires_in: number;
+		auth_time: number;
+		idle_at: number;
+		expires_at: number;
+		refresh_token: string;
+		refresh_expires_in: number;
+	  };
+
+export type KeycloakTokens = {
+  accessToken: string;
+  accessTokenExpiresIn: number;
+  authTime: number;
+  idleAt: number;
+  expiresAt: number;
+  refreshToken: string | null;
+  refreshTokenExpiresIn: number | null;
+};
+
+export type Claims = {
+	exp: number,
+	iat: number,
+	auth_time: number,
+	realm_access: { roles: string[] }
+	resource_access: { [key: string]: { 'roles': string[] } }
+}
+
+export type KeycloakUser = {
+  sub: string;  // user_id
+  name: string;
+  preferred_username: string;
+  given_name: string;
+  locale: string;
+  family_name: string;
+  email: string;
+  email_verified: boolean;
+};
+
+export type KeycloakRole = {
+	type: "realm" | "resource",
+	client: null | string, // null if realm_access
+	role: string
+}

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -106,7 +106,7 @@ export class KeycloakAuth<
 				accessTokenExpiresIn: tokens.expires_in,
 				authTime: tokenDecoded.auth_time,
 				issuedAtTime: tokenDecoded.iat,
-				expirationTime: tokenDecoded.exp,
+				expiresAt: tokenDecoded.exp,
 				refreshToken: tokens.refresh_token,
 				refreshTokenExpiresIn: tokens.refresh_expires_in
 			};
@@ -116,7 +116,7 @@ export class KeycloakAuth<
 			accessTokenExpiresIn: tokens.expires_in,
 			authTime: tokenDecoded.auth_time,
 			issuedAtTime: tokenDecoded.iat,
-			expirationTime: tokenDecoded.exp,
+			expiresAt: tokenDecoded.exp,
 			refreshToken: null,
 			refreshTokenExpiresIn: null
 		};
@@ -193,14 +193,14 @@ type AccessTokenResponseBody =
 			access_token: string;
 			expires_in: number;
 			auth_time: number;
-			idle_at: number;
+			issued_at_time: number;
 			expires_at: number;
 	  }
 	| {
 			access_token: string;
 			expires_in: number;
 			auth_time: number;
-			idle_at: number;
+			issued_at_time: number;
 			expires_at: number;
 			refresh_token: string;
 			refresh_expires_in: number;
@@ -211,7 +211,7 @@ export type KeycloakTokens = {
 	accessTokenExpiresIn: number;
 	authTime: number;
 	issuedAtTime: number;
-	expirationTime: number;
+	expiresAt: number;
 	refreshToken: string | null;
 	refreshTokenExpiresIn: number | null;
 };

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -11,12 +11,12 @@ import { handleRequest, authorizationHeader } from "../utils/request.js";
 import type { Auth } from "lucia";
 
 type Config = {
-  domain: string;
-  realm: string;
-  clientId: string;
-  clientSecret: string;
-  scope?: string[];
-  redirectUri?: string;
+	domain: string;
+	realm: string;
+	clientId: string;
+	clientSecret: string;
+	scope?: string[];
+	redirectUri?: string;
 };
 
 const PROVIDER_ID = "keycloak";
@@ -28,9 +28,9 @@ export const keycloak = <_Auth extends Auth = Auth>(
 	return new KeycloakAuth(auth, config);
 };
 
-export class KeycloakAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuthWithPKCE<
-	KeycloakUserAuth<_Auth>
-> {
+export class KeycloakAuth<
+	_Auth extends Auth = Auth
+> extends OAuth2ProviderAuthWithPKCE<KeycloakUserAuth<_Auth>> {
 	private config: Config;
 
 	constructor(auth: _Auth, config: Config) {
@@ -42,51 +42,64 @@ export class KeycloakAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuthW
 	public getAuthorizationUrl = async (): Promise<
 		readonly [url: URL, codeVerifier: string, state: string]
 	> => {
-    const scopeConfig = this.config.scope ?? [];
+		const scopeConfig = this.config.scope ?? [];
 		return await createOAuth2AuthorizationUrlWithPKCE(
-			`https://${ this.config.domain }/realms/${ this.config.realm }/protocol/openid-connect/auth`,
+			`https://${this.config.domain}/realms/${this.config.realm}/protocol/openid-connect/auth`,
 			{
-        clientId: this.config.clientId,
-        scope: ["profile", "openid", ...scopeConfig],
-        redirectUri: this.config.redirectUri,
-        codeChallengeMethod: "S256"
+				clientId: this.config.clientId,
+				scope: ["profile", "openid", ...scopeConfig],
+				redirectUri: this.config.redirectUri,
+				codeChallengeMethod: "S256"
 			}
 		);
 	};
 
 	public validateCallback = async (
 		code: string,
-    code_verifier: string
+		code_verifier: string
 	): Promise<KeycloakUserAuth<_Auth>> => {
-		const keycloakTokens = await this.validateAuthorizationCode(code, code_verifier);
-		const keycloakUser = await getKeycloakUser(this.config.domain, this.config.realm, keycloakTokens.accessToken);
-		const keycloakRoles = getKeycloakRoles(keycloakTokens.accessToken)
-		return new KeycloakUserAuth(this.auth, keycloakUser, keycloakTokens, keycloakRoles);
+		const keycloakTokens = await this.validateAuthorizationCode(
+			code,
+			code_verifier
+		);
+		const keycloakUser = await getKeycloakUser(
+			this.config.domain,
+			this.config.realm,
+			keycloakTokens.accessToken
+		);
+		const keycloakRoles = getKeycloakRoles(keycloakTokens.accessToken);
+		return new KeycloakUserAuth(
+			this.auth,
+			keycloakUser,
+			keycloakTokens,
+			keycloakRoles
+		);
 	};
 
 	private validateAuthorizationCode = async (
 		code: string,
-    codeVerifier: string
+		codeVerifier: string
 	): Promise<KeycloakTokens> => {
-		const rawTokens = await validateOAuth2AuthorizationCode<AccessTokenResponseBody>(
-			code,
-			`https://${ this.config.domain }/realms/${ this.config.realm }/protocol/openid-connect/token`,
-			{
-				clientId: this.config.clientId,
-				redirectUri: this.config.redirectUri,
-				codeVerifier,
-				clientPassword: {
-					authenticateWith: "http_basic_auth",
-					clientSecret: this.config.clientSecret
+		const rawTokens =
+			await validateOAuth2AuthorizationCode<AccessTokenResponseBody>(
+				code,
+				`https://${this.config.domain}/realms/${this.config.realm}/protocol/openid-connect/token`,
+				{
+					clientId: this.config.clientId,
+					redirectUri: this.config.redirectUri,
+					codeVerifier,
+					clientPassword: {
+						authenticateWith: "http_basic_auth",
+						clientSecret: this.config.clientSecret
+					}
 				}
-			}
-		);
+			);
 
-		return this.claimTokens(rawTokens)
+		return this.claimTokens(rawTokens);
 	};
 
 	private claimTokens = (tokens: AccessTokenResponseBody): KeycloakTokens => {
-		const tokenDecoded = decodeIdToken<Claims>(tokens.access_token)
+		const tokenDecoded = decodeIdToken<Claims>(tokens.access_token);
 
 		if ("refresh_token" in tokens) {
 			return {
@@ -96,7 +109,7 @@ export class KeycloakAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuthW
 				idleAt: tokenDecoded.iat,
 				expiresAt: tokenDecoded.exp,
 				refreshToken: tokens.refresh_token,
-				refreshTokenExpiresIn: tokens.refresh_expires_in,
+				refreshTokenExpiresIn: tokens.refresh_expires_in
 			};
 		}
 		return {
@@ -106,56 +119,68 @@ export class KeycloakAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuthW
 			idleAt: tokenDecoded.iat,
 			expiresAt: tokenDecoded.exp,
 			refreshToken: null,
-			refreshTokenExpiresIn: null,
+			refreshTokenExpiresIn: null
 		};
-	}
+	};
 }
 
-const getKeycloakUser = async (domain: string, realm: string, accessToken: string): Promise<KeycloakUser> => {
-	const keycloakUserRequest = new Request(`https://${ domain }/realms/${ realm }/protocol/openid-connect/userinfo`, {
-		headers: {
-			Authorization: authorizationHeader("bearer", accessToken)
+const getKeycloakUser = async (
+	domain: string,
+	realm: string,
+	accessToken: string
+): Promise<KeycloakUser> => {
+	const keycloakUserRequest = new Request(
+		`https://${domain}/realms/${realm}/protocol/openid-connect/userinfo`,
+		{
+			headers: {
+				Authorization: authorizationHeader("bearer", accessToken)
+			}
 		}
-	});
+	);
 	return await handleRequest<KeycloakUser>(keycloakUserRequest);
 };
 
 const getKeycloakRoles = (accessToken: string): KeycloakRole[] => {
-	const tokenDecoded: Claims = decodeIdToken<Claims>(accessToken)
-	const keycloakRoles: KeycloakRole[] = []
+	const tokenDecoded: Claims = decodeIdToken<Claims>(accessToken);
+	const keycloakRoles: KeycloakRole[] = [];
 
-	if (tokenDecoded.hasOwnProperty('realm_access')) {
+	if (tokenDecoded.hasOwnProperty("realm_access")) {
 		for (const role of tokenDecoded.realm_access.roles) {
 			keycloakRoles.push({
-				role_type: 'realm',
+				role_type: "realm",
 				client: null,
 				role: role
-			})
+			});
 		}
 	}
-	if (tokenDecoded.hasOwnProperty('resource_access')) {
+	if (tokenDecoded.hasOwnProperty("resource_access")) {
 		for (const [key, client] of Object.entries(tokenDecoded.resource_access)) {
 			for (const role of client.roles) {
 				keycloakRoles.push({
-					role_type: 'resource',
+					role_type: "resource",
 					client: key,
 					role: role
-				})
+				});
 			}
 		}
 	}
 
-	return keycloakRoles
-}
+	return keycloakRoles;
+};
 
 export class KeycloakUserAuth<
 	_Auth extends Auth
 > extends ProviderUserAuth<_Auth> {
 	public keycloakTokens: KeycloakTokens;
 	public keycloakUser: KeycloakUser;
-	public keycloakRoles: KeycloakRole[]
+	public keycloakRoles: KeycloakRole[];
 
-	constructor(auth: _Auth, keycloakUser: KeycloakUser, keycloakTokens: KeycloakTokens, keycloakRoles: KeycloakRole[]) {
+	constructor(
+		auth: _Auth,
+		keycloakUser: KeycloakUser,
+		keycloakTokens: KeycloakTokens,
+		keycloakRoles: KeycloakRole[]
+	) {
 		super(auth, PROVIDER_ID, keycloakUser.sub);
 
 		this.keycloakTokens = keycloakTokens;
@@ -173,60 +198,60 @@ type AccessTokenResponseBody =
 			expires_at: number;
 	  }
 	| {
-		access_token: string;
-		expires_in: number;
-		auth_time: number;
-		idle_at: number;
-		expires_at: number;
-		refresh_token: string;
-		refresh_expires_in: number;
+			access_token: string;
+			expires_in: number;
+			auth_time: number;
+			idle_at: number;
+			expires_at: number;
+			refresh_token: string;
+			refresh_expires_in: number;
 	  };
 
 export type KeycloakTokens = {
-  accessToken: string;
-  accessTokenExpiresIn: number;
-  authTime: number;
-  idleAt: number;
-  expiresAt: number;
-  refreshToken: string | null;
-  refreshTokenExpiresIn: number | null;
+	accessToken: string;
+	accessTokenExpiresIn: number;
+	authTime: number;
+	idleAt: number;
+	expiresAt: number;
+	refreshToken: string | null;
+	refreshTokenExpiresIn: number | null;
 };
 
 export type Claims = {
-	exp: number,
-	iat: number,
-	auth_time: number,
-	realm_access: { roles: string[] }
-	resource_access: { [key: string]: { 'roles': string[] } }
-}
+	exp: number;
+	iat: number;
+	auth_time: number;
+	realm_access: { roles: string[] };
+	resource_access: { [key: string]: { roles: string[] } };
+};
 
 export type KeycloakUser = {
-    exp: number;
-    iat: number;
-    auth_time: number;
-    jti: string;
-    iss: string;
-    aud: string;
-    sub: string;  // user_id
-    typ: string;
-    azp: string;
-    session_state: string;
-    at_hash: string;
-    acr: string;
-    sid: string;
-    email_verified: boolean;
-    name: string;
-    preferred_username: string;
-    given_name: string;
+	exp: number;
+	iat: number;
+	auth_time: number;
+	jti: string;
+	iss: string;
+	aud: string;
+	sub: string; // user_id
+	typ: string;
+	azp: string;
+	session_state: string;
+	at_hash: string;
+	acr: string;
+	sid: string;
+	email_verified: boolean;
+	name: string;
+	preferred_username: string;
+	given_name: string;
 	locale: string;
-    family_name: string;
-    email: string;
-    picture: string;
-    user: any;
-}
+	family_name: string;
+	email: string;
+	picture: string;
+	user: any;
+};
 
 export type KeycloakRole = {
-	role_type: "realm" | "resource",
-	client: null | string, // null if realm_access
-	role: string
-}
+	role_type: "realm" | "resource";
+	client: null | string; // null if realm_access
+	role: string;
+};

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -98,15 +98,13 @@ export class KeycloakAuth<
 	};
 
 	private claimTokens = (tokens: AccessTokenResponseBody): KeycloakTokens => {
-		const tokenDecoded = decodeIdToken<Claims>(tokens.access_token);
-
 		if ("refresh_token" in tokens) {
 			return {
 				accessToken: tokens.access_token,
 				accessTokenExpiresIn: tokens.expires_in,
-				authTime: tokenDecoded.auth_time,
-				issuedAtTime: tokenDecoded.iat,
-				expiresAt: tokenDecoded.exp,
+				authTime: tokens.auth_time,
+				issuedAtTime: tokens.issued_at_time,
+				expiresAt: tokens.expires_at,
 				refreshToken: tokens.refresh_token,
 				refreshTokenExpiresIn: tokens.refresh_expires_in
 			};
@@ -114,9 +112,9 @@ export class KeycloakAuth<
 		return {
 			accessToken: tokens.access_token,
 			accessTokenExpiresIn: tokens.expires_in,
-			authTime: tokenDecoded.auth_time,
-			issuedAtTime: tokenDecoded.iat,
-			expiresAt: tokenDecoded.exp,
+			authTime: tokens.auth_time,
+			issuedAtTime: tokens.issued_at_time,
+			expiresAt: tokens.expires_at,
 			refreshToken: null,
 			refreshTokenExpiresIn: null
 		};
@@ -143,7 +141,7 @@ const getKeycloakRoles = (accessToken: string): KeycloakRole[] => {
 	const tokenDecoded: Claims = decodeIdToken<Claims>(accessToken);
 	const keycloakRoles: KeycloakRole[] = [];
 
-	if (tokenDecoded.hasOwnProperty("realm_access")) {
+	if ("realm_access" in tokenDecoded) {
 		for (const role of tokenDecoded.realm_access.roles) {
 			keycloakRoles.push({
 				role_type: "realm",
@@ -152,7 +150,7 @@ const getKeycloakRoles = (accessToken: string): KeycloakRole[] => {
 			});
 		}
 	}
-	if (tokenDecoded.hasOwnProperty("resource_access")) {
+	if ("resource_access" in tokenDecoded) {
 		for (const [key, client] of Object.entries(tokenDecoded.resource_access)) {
 			for (const role of client.roles) {
 				keycloakRoles.push({

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -127,7 +127,7 @@ const getKeycloakRoles = (accessToken: string): KeycloakRole[] => {
 	if (tokenDecoded.hasOwnProperty('realm_access')) {
 		for (const role of tokenDecoded.realm_access.roles) {
 			keycloakRoles.push({
-				type: 'realm',
+				role_type: 'realm',
 				client: null,
 				role: role
 			})
@@ -137,7 +137,7 @@ const getKeycloakRoles = (accessToken: string): KeycloakRole[] => {
 		for (const [key, client] of Object.entries(tokenDecoded.resource_access)) {
 			for (const role of client.roles) {
 				keycloakRoles.push({
-					type: 'resource',
+					role_type: 'resource',
 					client: key,
 					role: role
 				})
@@ -226,7 +226,7 @@ export type KeycloakUser = {
 }
 
 export type KeycloakRole = {
-	type: "realm" | "resource",
+	role_type: "realm" | "resource",
 	client: null | string, // null if realm_access
 	role: string
 }

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -223,15 +223,28 @@ export type Claims = {
 }
 
 export type KeycloakUser = {
-  sub: string;  // user_id
-  name: string;
-  preferred_username: string;
-  given_name: string;
-  locale: string;
-  family_name: string;
-  email: string;
-  email_verified: boolean;
-};
+    exp: number;
+    iat: number;
+    auth_time: number;
+    jti: string;
+    iss: string;
+    aud: string;
+    sub: string;  // user_id
+    typ: string;
+    azp: string;
+    session_state: string;
+    at_hash: string;
+    acr: string;
+    sid: string;
+    email_verified: boolean;
+    name: string;
+    preferred_username: string;
+    given_name: string;
+    family_name: string;
+    email: string;
+    picture: string;
+    user: any;
+}
 
 export type KeycloakRole = {
 	type: "realm" | "resource",


### PR DESCRIPTION
This Adds Keycloak as a new provider.

-> Added Keycloak.ts and updated index.ts

As this is a self-hosted provider, following settings need to be set:

keycloakClientId: "`ClientId`",
keycloakClientSecret: "`ClientSecret`",
keycloakAuthEndpoint: "https://`domain`/realms/`realm`/protocol/openid-connect/auth",
keycloakTokenEndpoint: "https://`domain`/realms/`realm`/protocol/openid-connect/token",
keycloakUserinfoEndpoint: "https://`domain`/realms/`realm`/protocol/openid-connect/userinfo",
authRedirectUri: "`url to callback`"