### PR TITLE
docs: update examples link

### DIFF
--- a/documentation/content/main/getting-started/index.md
+++ b/documentation/content/main/getting-started/index.md
@@ -137,7 +137,7 @@ node --experimental-global-webcrypto index.js
 
 ## Next steps
 
-You can learn all the concepts and general APIs of Lucia by reading the [Basics](/basics/database) section in the docs. If you prefer writing code immediately, check out the [Starter guides](/starter-guides) page or the [examples in the repository](https://github.com/lucia-auth/lucia/tree/main/examples).
+You can learn all the concepts and general APIs of Lucia by reading the [Basics](/basics/database) section in the docs. If you prefer writing code immediately, check out the [Starter guides](/starter-guides) page or the [examples in the repository](https://github.com/lucia-auth/examples).
 
 Remember to check out the [Guidebook](/guidebook) for tutorials and guides! If you have any questions, join our [Discord server](/discord)!
 


### PR DESCRIPTION
the link to examples was pointing to a folder inside the main repo, updated it to point at eamples repo