### PR TITLE
remove backticks breaking h2 styling

### DIFF
--- a/documentation/content/main/migrate/v2/index.md
+++ b/documentation/content/main/migrate/v2/index.md
@@ -50,7 +50,7 @@ See each database adapter package's migration guide:
 - [`@lucia-auth/adapter-session-redis`](/migrate/v2/redis)
 - [`@lucia-auth/adapter-sqlite`](/migrate/v2/sqlite)
 
-## `Lucia` namespace
+## Lucia namespace
 
 ```ts
 /// <reference types="lucia" />


### PR DESCRIPTION
The backticks in the header cause some CSS issue in Chrome and Firefox. This PR just removes the backticks, you might prefer to solve adapt the CSS.

Screenshot:
![image](https://github.com/lucia-auth/lucia/assets/1546926/d42a13c5-7c88-4cf7-abdd-52cb16980793)
