### PR TITLE
fix code example on github oauth in nextjs app router guidebook

### DIFF
--- a/documentation/content/guidebook/github-oauth/$nextjs-app.md
+++ b/documentation/content/guidebook/github-oauth/$nextjs-app.md
@@ -163,7 +163,7 @@ Create `app/login/github/route.ts` and handle GET requests. [`GithubProvider.get
 
 ```ts
 // app/login/github/route.ts
-import { auth, githubAuth } from "@/auth/lucia";
+import { githubAuth } from "@/auth/lucia";
 import * as context from "next/headers";
 
 import type { NextRequest } from "next/server";
@@ -171,7 +171,7 @@ import type { NextRequest } from "next/server";
 export const GET = async (request: NextRequest) => {
 	const [url, state] = await githubAuth.getAuthorizationUrl();
 	// store state
-	cookies().set("github_oauth_state", state, {
+	context.cookies().set("github_oauth_state", state, {
 		httpOnly: true,
 		secure: process.env.NODE_ENV === "production",
 		path: "/",


### PR DESCRIPTION
I try to follow this guidebook https://lucia-auth.com/guidebook/github-oauth/nextjs-app/ to integrate my nextjs app with github oauth. I copy all code example in guide book but i get this error `Cannot find name 'cookies'. Did you mean 'Cookies'?`. It's turns out there is a typo on this code example
```ts
// app/login/github/route.ts
import { auth, githubAuth } from "@/auth/lucia";
import * as context from "next/headers";

import type { NextRequest } from "next/server";

export const GET = async (request: NextRequest) => {
	const [url, state] = await githubAuth.getAuthorizationUrl();
	// store state 
	cookies().set("github_oauth_state", state, {
		httpOnly: true,
		secure: process.env.NODE_ENV === "production",
		path: "/",
		maxAge: 60 * 60
	});
        // typo here ^ Cannot find name 'cookies'. Did you mean 'Cookies'?
	return new Response(null, {
		status: 302,
		headers: {
			Location: url.toString()
		}
	});
};
```
So I change the code example to this and it's work
```ts
// app/login/github/route.ts
import { githubAuth } from "@/auth/lucia";
import * as context from "next/headers";

import type { NextRequest } from "next/server";

export const GET = async (request: NextRequest) => {
	const [url, state] = await githubAuth.getAuthorizationUrl();
	// store state
	context.cookies().set("github_oauth_state", state, {
		httpOnly: true,
		secure: process.env.NODE_ENV === "production",
		path: "/",
		maxAge: 60 * 60
	});
        // add context here ^
	return new Response(null, {
		status: 302,
		headers: {
			Location: url.toString()
		}
	});
};
```
This PR change code example on guide book based on example above.