### PR TITLE
Fix default Slack scopes in documentation

### DIFF
--- a/documentation/content/oauth/providers/slack.md
+++ b/documentation/content/oauth/providers/slack.md
@@ -14,7 +14,7 @@ const slackAuth = slack(auth, configs);
 
 ## `slack()`
 
-Scopes `oidc` and `profile` are always included.
+Scopes `openid` and `profile` are always included.
 
 ```ts
 const slack: (


### PR DESCRIPTION
To reflect changes made in #1147 

Not sure if this needs a changeset since this is a documentation change?