### PR TITLE
fix(doc): await missing in example

### DIFF
--- a/documentation/content/main/basics/fallback-database-queries.md
+++ b/documentation/content/main/basics/fallback-database-queries.md
@@ -47,7 +47,7 @@ await db.transaction((trx) => {
 	await trx.key.insert({
 		id: createKeyId("username", username),
 		user_id: userId,
-		hashed_password: generateLuciaPasswordHash(password)
+		hashed_password: await generateLuciaPasswordHash(password)
 	});
 });
 ```


### PR DESCRIPTION
I followed this document using prisma transaction and I had to add the `await` keyword before `generateLuciaPasswordHash(password)` as in:

```
await tx.proKey.create({
  select: {
    id: true
  },
  data: {
    id: createKeyId('email', email),
    user_id: user.id,
    hashed_password: await generateLuciaPasswordHash(password)
  }
})
```