### PR TITLE
Fixed validateSession called instead of getSessions

### DIFF
--- a/documentation/content/main/basics/sessions.md
+++ b/documentation/content/main/basics/sessions.md
@@ -147,7 +147,7 @@ import { auth } from "./lucia.js";
 import { LuciaError } from "lucia";
 
 try {
-	const session = await auth.validateSession(sessionId);
+	const session = await auth.getSession(sessionId);
 	if (session.state === "active") {
 		// valid sessions
 	} else {


### PR DESCRIPTION
In the code example of `the Auth.getSessions()` API, the `Auth.validateSession()` has been called by mistake.