### PR TITLE
CI: Release

### DIFF
--- a/.auri/$9ry8sulh.md
+++ b/.auri/$9ry8sulh.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Stop escaping table names with a schema defined

--- a/.auri/$avmnsr2u.md
+++ b/.auri/$avmnsr2u.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth"
-type: "minor"
----
-
-Add `serverUrl` param to `GitlabAuth` config

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-postgresql
 
+## 2.0.2
+
+### Patch changes
+
+- [#1237](https://github.com/lucia-auth/lucia/pull/1237) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Stop escaping table names with a schema defined
+
 ## 2.0.1
 
 ### Patch changes

--- a/packages/adapter-postgresql/package.json
+++ b/packages/adapter-postgresql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-postgresql",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "PostgreSQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 3.4.0
+
+### Minor changes
+
+- [#1230](https://github.com/lucia-auth/lucia/pull/1230) by [@andr35](https://github.com/andr35) : Add `serverUrl` param to `GitlabAuth` config
+
 ## 3.3.2
 
 ### Patch changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "3.3.2",
+	"version": "3.4.0",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/adapter-postgresql@2.0.2
#### Patch changes

- [#1237](https://github.com/lucia-auth/lucia/pull/1237) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Stop escaping table names with a schema defined
### @lucia-auth/oauth@3.4.0
#### Minor changes

- [#1230](https://github.com/lucia-auth/lucia/pull/1230) by [@andr35](https://github.com/andr35) : Add `serverUrl` param to `GitlabAuth` config