### PR TITLE
CI: Release

### DIFF
--- a/.auri/$4u4hf1ka.md
+++ b/.auri/$4u4hf1ka.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Adds Keycloak Provider

--- a/.auri/$9i49vkeh.md
+++ b/.auri/$9i49vkeh.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Revert #1158

--- a/.auri/$fy4dnvrh.md
+++ b/.auri/$fy4dnvrh.md
@@ -1,6 +1,0 @@
----
-package: "lucia"
-type: "patch"
----
-
-Allow debug message to be displayed when request origin not available

--- a/.auri/$l1wuy8uf.md
+++ b/.auri/$l1wuy8uf.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mongoose" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependencies

--- a/.auri/$q39oadap.md
+++ b/.auri/$q39oadap.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Remove unused `svelte` field from `package.json`

--- a/.auri/$qxgfzmll.md
+++ b/.auri/$qxgfzmll.md
@@ -1,7 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Kakao provider
-

--- a/.auri/$z7910syc.md
+++ b/.auri/$z7910syc.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Remove `nanoid` dependency

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-mongoose
 
+## 3.0.1
+
+### Patch changes
+
+- [#1248](https://github.com/lucia-auth/lucia/pull/1248) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependencies
+
 ## 3.0.0
 
 ### Major changes

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mongoose",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "Mongoose (MongoDB) adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,17 @@
 # lucia
 
+## 2.7.4
+
+### Patch changes
+
+- [#1250](https://github.com/lucia-auth/lucia/pull/1250) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Revert #1158
+
+- [#1256](https://github.com/lucia-auth/lucia/pull/1256) by [@FredTreg](https://github.com/FredTreg) : Allow debug message to be displayed when request origin not available
+
+- [#1254](https://github.com/lucia-auth/lucia/pull/1254) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove unused `svelte` field from `package.json`
+
+- [#1250](https://github.com/lucia-auth/lucia/pull/1250) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `nanoid` dependency
+
 ## 2.7.3
 
 ### Patch changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.7.3",
+	"version": "2.7.4",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/oauth
 
+## 3.5.0
+
+### Minor changes
+
+- [#1165](https://github.com/lucia-auth/lucia/pull/1165) by [@Ed1ks](https://github.com/Ed1ks) : Adds Keycloak Provider
+
+- [#1207](https://github.com/lucia-auth/lucia/pull/1207) by [@sjunepark](https://github.com/sjunepark) : Add Kakao provider
+
 ## 3.4.0
 
 ### Minor changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "3.4.0",
+	"version": "3.5.0",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/src/providers/index.ts
+++ b/packages/oauth/src/providers/index.ts
@@ -97,7 +97,6 @@ export type {
 	GoogleUserAuth
 } from "./google.js";
 
-
 export { kakao } from "./kakao.js";
 export type {
 	KakaoAuth,


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@3.5.0
#### Minor changes

- [#1165](https://github.com/lucia-auth/lucia/pull/1165) by [@Ed1ks](https://github.com/Ed1ks) : Adds Keycloak Provider

- [#1207](https://github.com/lucia-auth/lucia/pull/1207) by [@sjunepark](https://github.com/sjunepark) : Add Kakao provider
### lucia@2.7.4
#### Patch changes

- [#1250](https://github.com/lucia-auth/lucia/pull/1250) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Revert #1158

- [#1256](https://github.com/lucia-auth/lucia/pull/1256) by [@FredTreg](https://github.com/FredTreg) : Allow debug message to be displayed when request origin not available

- [#1254](https://github.com/lucia-auth/lucia/pull/1254) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove unused `svelte` field from `package.json`

- [#1250](https://github.com/lucia-auth/lucia/pull/1250) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `nanoid` dependency
### @lucia-auth/adapter-mongoose@3.0.1
#### Patch changes

- [#1248](https://github.com/lucia-auth/lucia/pull/1248) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependencies