### PR TITLE
Performance improvement: do not query database when not needed for a dual database/redis setup

### DIFF
--- a/.auri/$3nomjpn5.md
+++ b/.auri/$3nomjpn5.md
@@ -1,0 +1,6 @@
+---
+package: "lucia"
+type: "patch"
+---
+
+Optimize validation of sessions for a dual database/redis setup

--- a/packages/lucia/src/auth/index.ts
+++ b/packages/lucia/src/auth/index.ts
@@ -78,6 +78,7 @@ export class Auth<_Configuration extends Configuration = any> {
 	private experimental: {
 		debugMode: boolean;
 	};
+	private fetchUserAttributes: boolean;
 
 	constructor(config: _Configuration) {
 		validateConfiguration(config);
@@ -116,6 +117,7 @@ export class Auth<_Configuration extends Configuration = any> {
 		this.experimental = {
 			debugMode: config.experimental?.debugMode ?? false
 		};
+    this.fetchUserAttributes = config.getUserAttributes !== undefined;
 
 		debug.init(this.experimental.debugMode);
 	}
@@ -224,7 +226,9 @@ export class Auth<_Configuration extends Configuration = any> {
 			return [databaseSession, databaseUser];
 		}
 		const databaseSession = await this.getDatabaseSession(sessionId);
-		const databaseUser = await this.getDatabaseUser(databaseSession.user_id);
+		const databaseUser = this.fetchUserAttributes
+			? await this.getDatabaseUser(databaseSession.user_id)
+			: { id: databaseSession.user_id };
 		return [databaseSession, databaseUser];
 	};
 


### PR DESCRIPTION
I propose this PR as a transparent version of the feature request #1257 I opened.

In case the feature request is not approved (for example for bringing complexity to lucia interfaces), this PR solves my performance issues on a dual database/redis setup while not impacting existing code.

The only side effect I see is that the `validateSession()` or `getSession()` would no longer potentially throw a `AUTH_INVALID_USER_ID` exception when no `getUserAttributes` function is defined in a dual user/session adapters setup. But not having a user when a session exists should never happen anyway.