### PR TITLE
docs: @neonserverless/database to @neondatabase/serverless

### DIFF
--- a/documentation/content/guidebook/drizzle-orm.md
+++ b/documentation/content/guidebook/drizzle-orm.md
@@ -7,7 +7,7 @@ description: "Learn how to use Drizzle ORM with Lucia"
 
 ## MySQL
 
-Make sure to change the table names accordingly. While you can name your Drizzle fields anything you want, the underlying column names must match what's defined in the docs (e.g `user_id`). 
+Make sure to change the table names accordingly. While you can name your Drizzle fields anything you want, the underlying column names must match what's defined in the docs (e.g `user_id`).
 
 ```ts
 // schema.js
@@ -138,7 +138,7 @@ export const auth = lucia({
 
 We recommend using `pg` with TCP connections for Supabase and Neon.
 
-Make sure to change the table names accordingly. While you can name your Drizzle fields anything you want, the underlying column names must match what's defined in the docs (e.g `user_id`). 
+Make sure to change the table names accordingly. While you can name your Drizzle fields anything you want, the underlying column names must match what's defined in the docs (e.g `user_id`).
 
 ```ts
 // schema.js
@@ -251,7 +251,7 @@ export const auth = lucia({
 
 ## SQLite
 
-Make sure to change the table names accordingly. While you can name your Drizzle fields anything you want, the underlying column names must match what's defined in the docs (e.g `user_id`). 
+Make sure to change the table names accordingly. While you can name your Drizzle fields anything you want, the underlying column names must match what's defined in the docs (e.g `user_id`).
 
 ```ts
 // schema.js

--- a/documentation/content/main/basics/database.md
+++ b/documentation/content/main/basics/database.md
@@ -23,7 +23,7 @@ We currently provide the following adapters:
 - [Redis](/database-adapters/redis)
 - [Unstorage](/database-adapters/unstorage)
 
-SDKs such as `@vercel/postgres` and `@neonserverless/database` provide drop-in replacements for existing drivers. You can also use query builders like Drizzle ORM and Kysely since they rely on underlying drivers that we provide adapters for. Refer to these guides:
+SDKs such as `@vercel/postgres` and `@neondatabase/serverless` provide drop-in replacements for existing drivers. You can also use query builders like Drizzle ORM and Kysely since they rely on underlying drivers that we provide adapters for. Refer to these guides:
 
 - [Using `@vercel/postgres`](/guidebook/vercel-postgres)
 - [Using Drizzle ORM](/guidebook/drizzle-orm)
@@ -87,7 +87,7 @@ declare namespace Lucia {
 	type DatabaseSessionAttributes = {
 		// required fields (i.e. id) should not be defined here
 		username: string;
-		display_name: string
+		display_name: string;
 	};
 }
 ```


### PR DESCRIPTION
I think this is a typo for the [`@neondatabase/serverless`](https://github.com/neondatabase/serverless) package