### PR TITLE
fix: session migration

### DIFF
--- a/documentation/src/pages/database/sqlite.md
+++ b/documentation/src/pages/database/sqlite.md
@@ -25,7 +25,7 @@ CREATE TABLE user (
 
 CREATE TABLE session (
     id TEXT NOT NULL PRIMARY KEY,
-    expires_at INTEGER NOT NULL PRIMARY KEY,
+    expires_at INTEGER NOT NULL,
     user_id TEXT NOT NULL,
     FOREIGN KEY (user_id) REFERENCES user(id)
 )


### PR DESCRIPTION
Removed the duplicated "PRIMARY KEY" declaration from the session table migration for SQLite.