### PR TITLE
Add default cookie path for SvelteKit

### DIFF
--- a/.auri/$usr71dkt.md
+++ b/.auri/$usr71dkt.md
@@ -3,4 +3,4 @@ package: "lucia"
 type: "patch"
 ---
 
-Adds a default path of `/` to cookies set with the SvelteKit middleware.
+Update SvelteKit middleware to be compatible with SvelteKit v2

--- a/.auri/$usr71dkt.md
+++ b/.auri/$usr71dkt.md
@@ -1,0 +1,6 @@
+---
+package: "lucia"
+type: "patch"
+---
+
+Adds a default path of `/` to cookies set with the SvelteKit middleware.

--- a/packages/lucia/src/middleware/index.ts
+++ b/packages/lucia/src/middleware/index.ts
@@ -129,8 +129,8 @@ type AstroAPIContext = {
 		set: (name: string, value: string, options?: CookieAttributes) => void;
 		get: (name: string) =>
 			| {
-				value: string | undefined;
-			}
+					value: string | undefined;
+			  }
 			| undefined;
 	};
 };
@@ -226,9 +226,9 @@ type NextJsPagesServerContext = {
 
 type NextCookie =
 	| {
-		name: string;
-		value: string;
-	}
+			name: string;
+			value: string;
+	  }
 	| undefined;
 
 type NextCookiesFunction = () => {

--- a/packages/lucia/src/middleware/index.ts
+++ b/packages/lucia/src/middleware/index.ts
@@ -103,7 +103,7 @@ export const fastify = (): Middleware<[FastifyRequest, FastifyReply]> => {
 type SvelteKitRequestEvent = {
 	request: Request;
 	cookies: {
-		set: (name: string, value: string, options?: CookieAttributes) => void;
+		set: (name: string, value: string, options: CookieAttributes & { path: string }) => void;
 		get: (name: string) => string | undefined;
 	};
 };
@@ -115,7 +115,7 @@ export const sveltekit = (): Middleware<[SvelteKitRequestEvent]> => {
 			request: event.request,
 			sessionCookie: event.cookies.get(sessionCookieName) ?? null,
 			setCookie: (cookie) => {
-				event.cookies.set(cookie.name, cookie.value, cookie.attributes);
+				event.cookies.set(cookie.name, cookie.value, { path: '/', ...cookie.attributes });
 			}
 		} as const satisfies RequestContext;
 
@@ -129,8 +129,8 @@ type AstroAPIContext = {
 		set: (name: string, value: string, options?: CookieAttributes) => void;
 		get: (name: string) =>
 			| {
-					value: string | undefined;
-			  }
+				value: string | undefined;
+			}
 			| undefined;
 	};
 };
@@ -226,9 +226,9 @@ type NextJsPagesServerContext = {
 
 type NextCookie =
 	| {
-			name: string;
-			value: string;
-	  }
+		name: string;
+		value: string;
+	}
 	| undefined;
 
 type NextCookiesFunction = () => {


### PR DESCRIPTION
Fixes #1300 by adding a default `path: '/'` to all cookies set through the SvelteKit middleware.

I don't love the shallow copy of the cookie attributes to add a default path, but I think it's better than an explicit cast, like:

```typescript
cookie.attributes.path ??= '/';

event.cookies.set(cookie.name, cookie.value, cookie.attributes as CookieAttributes & { path: string });
```