### PR TITLE
CI: Release

### DIFF
--- a/.auri/$vkd6ut3c.md
+++ b/.auri/$vkd6ut3c.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-session-redis" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix expiration

--- a/.auri/$ypf7ombn.md
+++ b/.auri/$ypf7ombn.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix `setCookie()` method in SvelteKit middleware

--- a/packages/adapter-session-redis/CHANGELOG.md
+++ b/packages/adapter-session-redis/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-session-redis
 
+## 2.1.2
+
+### Patch changes
+
+- [#1314](https://github.com/lucia-auth/lucia/pull/1314) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix expiration
+
 ## 2.1.1
 
 ### Patch changes

--- a/packages/adapter-session-redis/package.json
+++ b/packages/adapter-session-redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-session-redis",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "Redis session adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,11 @@
 # lucia
 
+## 2.7.6
+
+### Patch changes
+
+- [#1309](https://github.com/lucia-auth/lucia/pull/1309) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `setCookie()` method in SvelteKit middleware
+
 ## 2.7.5
 
 ### Patch changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.7.5",
+	"version": "2.7.6",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/adapter-session-redis@2.1.2
#### Patch changes

- [#1314](https://github.com/lucia-auth/lucia/pull/1314) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix expiration
### lucia@2.7.6
#### Patch changes

- [#1309](https://github.com/lucia-auth/lucia/pull/1309) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `setCookie()` method in SvelteKit middleware