### PR TITLE
fix: use transformDatabaseUser in transformDatabaseUser example

### DIFF
--- a/documentation/content/reference/lucia/interfaces/auth.md
+++ b/documentation/content/reference/lucia/interfaces/auth.md
@@ -669,7 +669,7 @@ const transformDatabaseUser: (databaseUser: UserSchema) => User;
 import { auth } from "./lucia.js";
 
 const databaseUser = await db.getUser(userId);
-const user = auth.transformDatabaseSession(databaseUser);
+const user = auth.transformDatabaseUser(databaseUser);
 ```
 
 ## `updateKeyPassword()`


### PR DESCRIPTION
The example for `auth.transformDatabaseUser` incorrectly uses `auth.transformDatabaseSession` instead of `auth.transformDatabaseUser`.