### PR TITLE
Fix SvelteKit docs line of text in a cell

### DIFF
--- a/docs/pages/tutorials/username-and-password/sveltekit.md
+++ b/docs/pages/tutorials/username-and-password/sveltekit.md
@@ -17,9 +17,11 @@ npx degit https://github.com/lucia-auth/examples/tree/v3/sveltekit/username-and-
 Add a `username` and `password` column to your user table.
 
 | column     | type     | attributes |
-| ---------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ---------- | -------- | ---------- |
 | `username` | `string` | unique     |
-| `password` | `string` |            | Create a `DatabaseUserAttributes` interface in the module declaration and add your database columns. By default, Lucia will not expose any database columns to the `User` type. To add a `username` field to it, use the `getUserAttributes()` option. |
+| `password` | `string` |            |
+
+Create a `DatabaseUserAttributes` interface in the module declaration and add your database columns. By default, Lucia will not expose any database columns to the `User` type. To add a `username` field to it, use the `getUserAttributes()` option.
 
 ```ts
 import { Lucia } from "lucia";


### PR DESCRIPTION
There is a line of text that has been added to a table cell by accident

![image](https://github.com/lucia-auth/lucia/assets/115825/5c0c2a7f-eeb4-471b-9a05-f0b27b23afac)

This should be a new paragraph under the table, which this MR moves it to.