### PR TITLE
Fix session attributes when getting all user sessions

### DIFF
--- a/packages/lucia/src/core.ts
+++ b/packages/lucia/src/core.ts
@@ -110,7 +110,7 @@ export class Lucia<
 				expiresAt: databaseSession.expiresAt,
 				userId: databaseSession.userId,
 				fresh: false,
-				...this.getSessionAttributes(databaseSession)
+				...this.getSessionAttributes(databaseSession.attributes)
 			});
 		}
 		return sessions;


### PR DESCRIPTION
This fixes an issue where the `getSessionAttributes` is not passed the correct raw DB attributes when called in `getUserSessions`.

Also thought this was such a small fix that an issue might not be needed (nor this PR to be honest, but it's a slow wednesday evening), if you'd prefer an issue linked to it just let me know.