### PR TITLE
fix: typo

### DIFF
--- a/docs/pages/database/drizzle.md
+++ b/docs/pages/database/drizzle.md
@@ -7,7 +7,7 @@ title: "Drizzle ORM"
 Adapters for Drizzle ORM are provided by `@lucia-auth/adapter-drizzle`. Supports MySQL, PostgreSQL, and SQLite. You're free to rename the underlying table and column names as long as the field names are the same (e.g. `expiresAt`).
 
 ```
-npm install @lucia-auth/adapter-sqlite@beta
+npm install @lucia-auth/adapter-drizzle@beta
 ```
 
 ## MySQL


### PR DESCRIPTION
The correct package should be ``@lucia-auth/adapter-drizzle`` instead of ``@lucia-auth/adapter-sqlite`` for Drizzle.