### PR TITLE
Implement `insecure` flag to Keycloak Provider

### DIFF
--- a/.auri/$d1g3thq0.md
+++ b/.auri/$d1g3thq0.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/oauth"
+type: "patch"
+---
+
+Adds `insecure` flag to `Keycloak` OAuth Provider, allowing users to connect to a local (or insecure) instance of Keycloak.

--- a/documentation/content/oauth/providers/keycloak.md
+++ b/documentation/content/oauth/providers/keycloak.md
@@ -24,6 +24,7 @@ const keycloak: (
 		clientSecret: string;
 		scope?: string[];
 		redirectUri?: string;
+		insecure?: boolean;
 	}
 ) => KeycloakProvider;
 ```
@@ -39,6 +40,7 @@ const keycloak: (
 | `config.clientSecret` | `string`                                   | Keycloak OAuth app client secret                    |          |
 | `config.scope`        | `string[]`                                 | an array of scopes                                  |    ✓     |
 | `config.redirectUri`  | `string`                                   | an authorized redirect URI                          |    ✓     |
+| `config.insecure`     | `boolean`                                  | redirects to http instead of https when true        |    ✓     |
 
 ##### Returns
 


### PR DESCRIPTION
## What's changed?

- Implement `insecure` flag to Keycloak Provider, this allows Lucia to connect to local, self-hosted instances that may be insecure or in a local network.
- fixes #1276 