### PR TITLE
Re-use `originFromDomain` utility function in Auth0 and Keycloak providers

### DIFF
--- a/.auri/$8h6jkpso.md
+++ b/.auri/$8h6jkpso.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/oauth"
+type: "patch"
+---
+
+Re-use `originFromDomain` utility function in Auth0 and Keycloak providers, allowing to connect to insecure origins of self-hosted Keycloak instances.

--- a/packages/oauth/src/providers/auth0.ts
+++ b/packages/oauth/src/providers/auth0.ts
@@ -4,7 +4,11 @@ import {
 	validateOAuth2AuthorizationCode
 } from "../core/oauth2.js";
 import { ProviderUserAuth } from "../core/provider.js";
-import { handleRequest, authorizationHeader } from "../utils/request.js";
+import {
+	handleRequest,
+	authorizationHeader,
+	originFromDomain
+} from "../utils/request.js";
 
 import type { Auth } from "lucia";
 
@@ -111,13 +115,6 @@ const getAuth0User = async (appDomain: string, accessToken: string) => {
 		...auth0Profile
 	};
 	return auth0User;
-};
-
-const originFromDomain = (domain: string): string => {
-	if (domain.startsWith("https://") || domain.startsWith("http://")) {
-		return domain;
-	}
-	return "https://" + domain;
 };
 
 export type Auth0Tokens = {

--- a/packages/oauth/src/providers/keycloak.ts
+++ b/packages/oauth/src/providers/keycloak.ts
@@ -5,7 +5,11 @@ import {
 } from "../core/oauth2.js";
 import { ProviderUserAuth } from "../core/provider.js";
 import { decodeIdToken } from "../index.js";
-import { handleRequest, authorizationHeader } from "../utils/request.js";
+import {
+	handleRequest,
+	authorizationHeader,
+	originFromDomain
+} from "../utils/request.js";
 
 import type { Auth } from "lucia";
 
@@ -43,7 +47,10 @@ export class KeycloakAuth<
 	> => {
 		const scopeConfig = this.config.scope ?? [];
 		return await createOAuth2AuthorizationUrlWithPKCE(
-			`https://${this.config.domain}/realms/${this.config.realm}/protocol/openid-connect/auth`,
+			new URL(
+				`/realms/${this.config.realm}/protocol/openid-connect/auth`,
+				originFromDomain(this.config.domain)
+			),
 			{
 				clientId: this.config.clientId,
 				scope: ["profile", "openid", ...scopeConfig],
@@ -82,7 +89,10 @@ export class KeycloakAuth<
 		const rawTokens =
 			await validateOAuth2AuthorizationCode<AccessTokenResponseBody>(
 				code,
-				`https://${this.config.domain}/realms/${this.config.realm}/protocol/openid-connect/token`,
+				new URL(
+					`realms/${this.config.realm}/protocol/openid-connect/token`,
+					originFromDomain(this.config.domain)
+				),
 				{
 					clientId: this.config.clientId,
 					redirectUri: this.config.redirectUri,
@@ -127,7 +137,10 @@ const getKeycloakUser = async (
 	accessToken: string
 ): Promise<KeycloakUser> => {
 	const keycloakUserRequest = new Request(
-		`https://${domain}/realms/${realm}/protocol/openid-connect/userinfo`,
+		new URL(
+			`realms/${realm}/protocol/openid-connect/userinfo`,
+			originFromDomain(domain)
+		),
 		{
 			headers: {
 				Authorization: authorizationHeader("bearer", accessToken)

--- a/packages/oauth/src/utils/request.ts
+++ b/packages/oauth/src/utils/request.ts
@@ -36,3 +36,10 @@ export const authorizationHeader = (
 	}
 	throw new TypeError("Invalid token type");
 };
+
+export const originFromDomain = (domain: string): string => {
+	if (domain.startsWith("https://") || domain.startsWith("http://")) {
+		return domain;
+	}
+	return "https://" + domain;
+};


### PR DESCRIPTION
## What's Changed?

- Re-use `originFromDomain` utility function in Auth0 and Keycloak providers, allowing to connect to insecure origins of self-hosted Keycloak instances.
- fixes #1276 