### PR TITLE
(V3) Update docs to use SvelteKit 2 redirect

### DIFF
--- a/docs/pages/guides/validate-session-cookies/sveltekit.md
+++ b/docs/pages/guides/validate-session-cookies/sveltekit.md
@@ -60,7 +60,7 @@ import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
 	if (!event.locals.user) {
-		throw redirect("/login");
+		 redirect("/login");
 	}
 	// ...
 };

--- a/docs/pages/tutorials/github-oauth/sveltekit.md
+++ b/docs/pages/tutorials/github-oauth/sveltekit.md
@@ -118,7 +118,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
 		sameSite: "lax"
 	});
 
-	return redirect(302, url.toString());
+	 redirect(302, url.toString());
 }
 ```
 
@@ -210,7 +210,7 @@ You can validate requests by checking `locals.user`. The field `user.username` i
 import type { PageServerLoad, Actions } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
-	if (!event.locals.user) throw redirect(302, "/login");
+	if (!event.locals.user)  redirect(302, "/login");
 	return {
 		username: event.locals.user.username
 	};
@@ -243,7 +243,7 @@ export const actions: Actions = {
 			path: ".",
 			...sessionCookie.attributes
 		});
-		return redirect(302, "/login");
+		 redirect(302, "/login");
 	}
 };
 ```

--- a/docs/pages/tutorials/username-and-password/sveltekit.md
+++ b/docs/pages/tutorials/username-and-password/sveltekit.md
@@ -123,7 +123,7 @@ export const actions: Actions = {
 			...sessionCookie.attributes
 		});
 
-		return redirect(302, "/");
+		 redirect(302, "/");
 	}
 };
 ```
@@ -217,7 +217,7 @@ export const actions: Actions = {
 			...sessionCookie.attributes
 		});
 
-		return redirect(302, "/");
+		 redirect(302, "/");
 	}
 };
 ```
@@ -231,7 +231,7 @@ You can validate requests by checking `locals.user`. The field `user.username` i
 import type { PageServerLoad, Actions } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
-	if (!event.locals.user) throw redirect(302, "/login");
+	if (!event.locals.user)  redirect(302, "/login");
 	return {
 		username: event.locals.user.username
 	};
@@ -264,7 +264,7 @@ export const actions: Actions = {
 			path: ".",
 			...sessionCookie.attributes
 		});
-		return redirect(302, "/login");
+		 redirect(302, "/login");
 	}
 };
 ```


### PR DESCRIPTION
## Description

Updated documentation to align with SvelteKit 2's redirect syntax. Changes involve simplifying the redirect command by removing the `throw` statement.

### Changes
- Modified redirect command in 3 files:
  - Replaced `throw redirect("/login");` with `redirect("/login");`.
