### PR TITLE
Fix v3 docs

### DIFF
--- a/docs/malta.config.json
+++ b/docs/malta.config.json
@@ -48,7 +48,7 @@
 			"pages": [
 				["Discord", "https://discord.com/invite/PwrK3kpVR3"],
 				["GitHub", "https://github.com/lucia-auth/lucia"],
-				["Twitter", "https://twitter.com/lucia-auth"]
+				["Twitter", "https://twitter.com/lucia_auth"]
 			]
 		}
 	]

--- a/docs/pages/basics/configuration.md
+++ b/docs/pages/basics/configuration.md
@@ -19,7 +19,7 @@ interface Options {
 
 ## `sessionExpiresIn`
 
-Configures how long a session is valid max for inactive users. Sessions expiration are automatically extended for active users. Also see [`TimeSpan`](/reference/main/TimeSpan).
+Configures how long a session stays valid for inactive users. Session expirations are automatically extended for active users. Also see [`TimeSpan`](/reference/main/TimeSpan).
 
 ```ts
 import { Lucia, TimeSpan } from "lucia";

--- a/docs/pages/basics/sessions.md
+++ b/docs/pages/basics/sessions.md
@@ -4,7 +4,7 @@ title: "Sessions"
 
 # Sessions
 
-Sessions allow Lucia to keep track of requests made by authenticated users. The id can be stored in a cookie or used as a traditional token manually added to each request. They should be created and stored on registration and login, validated on every request, and deleted on sign out.
+Sessions allow Lucia to keep track of requests made by authenticated users. The ID can be stored in a cookie or used as a traditional token manually added to each request. They should be created and stored on registration and login, validated on every request, and deleted on sign out.
 
 ```ts
 interface Session extends SessionAttributes {
@@ -17,9 +17,9 @@ interface Session extends SessionAttributes {
 
 ## Session lifetime
 
-Sessions do not have an absolute expiration. The expiration gets extended whenever they're used. This ensures that active users are signed in, while inactive users are signed out.
+Sessions do not have an absolute expiration. The expiration gets extended whenever they're used. This ensures that active users remain signed in, while inactive users are signed out.
 
-More specifically, if the session expiration is set to 30 days (default), Lucia will extend the expiration by another 30 days when there's less than 15 days (half of the expiration) until expiration. You can configure the expiration with the `sessionExpiresIn` configuration.
+More specifically, if the session expiration is set to 30 days (default), Lucia will extend the expiration by another 30 days when there are less than 15 days (half of the expiration) until expiration. You can configure the expiration with the `sessionExpiresIn` configuration.
 
 ```ts
 import { Lucia, TimeSpan } from "lucia";
@@ -45,7 +45,7 @@ declare module "lucia" {
 }
 ```
 
-You can then include them into the session object with the `getSessionAttributes()` configuration.
+You can then include them in the session object with the `getSessionAttributes()` configuration.
 
 ```ts
 const lucia = new Lucia(adapter, {
@@ -62,7 +62,7 @@ session.ipCountry;
 
 We do not automatically expose all database columns as
 
-1. Each project has their code styling rules
+1. Each project has its own code styling rules
 2. You generally don't want to expose sensitive data (even worse if you send the entire session object to the client)
 
 ## Create sessions
@@ -116,7 +116,7 @@ const sessionId = lucia.readSessionCookie("auth_session=abc");
 const sessionId = lucia.readBearerToken("Bearer abc");
 ```
 
-See the [Validate session cookies](/guides/validate-session-cookies) and [Validate bearer tokens](/guides/validate-bearer-tokens) guide for a full example for validating session cookies.
+See the [Validate session cookies](/guides/validate-session-cookies) and [Validate bearer tokens](/guides/validate-bearer-tokens) guide for a full example of validating session cookies.
 
 ## Session cookies
 

--- a/docs/pages/basics/users.md
+++ b/docs/pages/basics/users.md
@@ -51,7 +51,7 @@ interface DatabaseUserAttributes {
 }
 ```
 
-You can then include them into the user object with the `getUserAttributes()` configuration.
+You can then include them in the user object with the `getUserAttributes()` configuration.
 
 ```ts
 const lucia = new Lucia(adapter, {
@@ -70,5 +70,5 @@ if (user) {
 
 We do not automatically expose all database columns as
 
-1. Each project has their code styling rules
+1. Each project has its own code styling rules
 2. You generally don't want to expose sensitive data such as hashed passwords (even worse if you send the entire user object to the client)

--- a/docs/pages/getting-started/astro.md
+++ b/docs/pages/getting-started/astro.md
@@ -14,7 +14,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
 
 ```ts
 // src/auth.ts
@@ -38,7 +38,7 @@ declare module "lucia" {
 }
 ```
 
-## Setup middleware
+## Set up middleware
 
 We recommend setting up a middleware to validate requests. The validated user will be available as `local.user`. You can just copy-paste the code into `src/middleware.ts`.
 

--- a/docs/pages/getting-started/express.md
+++ b/docs/pages/getting-started/express.md
@@ -14,7 +14,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
 
 ```ts
 import { Lucia } from "lucia";

--- a/docs/pages/getting-started/index.md
+++ b/docs/pages/getting-started/index.md
@@ -24,7 +24,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
 
 ```ts
 import { Lucia } from "lucia";

--- a/docs/pages/getting-started/nextjs-app.md
+++ b/docs/pages/getting-started/nextjs-app.md
@@ -14,7 +14,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
 
 ```ts
 // src/auth.ts

--- a/docs/pages/getting-started/nextjs-pages.md
+++ b/docs/pages/getting-started/nextjs-pages.md
@@ -14,7 +14,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
 
 ```ts
 // src/auth.ts
@@ -53,7 +53,7 @@ globalThis.crypto = webcrypto as Crypto;
 node --experimental-web-crypto index.js
 ```
 
-## Setup middleware
+## Set up middleware
 
 If you're planning to use cookies, you must implement CSRF protection.
 

--- a/docs/pages/getting-started/nuxt.md
+++ b/docs/pages/getting-started/nuxt.md
@@ -14,7 +14,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
 
 - Configure the `sessionCookie` option
 - Register your `Lucia` instance type
@@ -57,7 +57,7 @@ globalThis.crypto = webcrypto as Crypto;
 node --experimental-web-crypto index.js
 ```
 
-## Setup middleware
+## Set up middleware
 
 We recommend setting up a middleware to validate requests. The validated user will be available as `event.context.user`. You can just copy-paste the code into `server/middleware/auth.ts`.
 

--- a/docs/pages/getting-started/solidstart.md
+++ b/docs/pages/getting-started/solidstart.md
@@ -14,7 +14,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
 
 ```ts
 // src/lib/auth.ts
@@ -38,7 +38,7 @@ declare module "lucia" {
 }
 ```
 
-## Setup middleware
+## Set up middleware
 
 We recommend setting up a middleware to validate requests. The validated user will be available as `context.user`. You can just copy-paste the code into `src/middleware.ts`.
 

--- a/docs/pages/getting-started/sveltekit.md
+++ b/docs/pages/getting-started/sveltekit.md
@@ -14,7 +14,7 @@ npm install lucia@beta oslo
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to setup your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
 
 ```ts
 // src/lib/server/auth.ts

--- a/docs/pages/guides/email-and-password/basics.md
+++ b/docs/pages/guides/email-and-password/basics.md
@@ -4,7 +4,7 @@ title: "Password basics"
 
 # Password basics
 
-This page covers how to implement a password-based auth with Lucia. If you're looking for a step-by-step, framework specific tutorial, you may want to check out the [Username and password](/tutorials/username-and-password) tutorial. Keep in mind that email based auth requires more than just passwords!
+This page covers how to implement a password-based auth with Lucia. If you're looking for a step-by-step, framework-specific tutorial, you may want to check out the [Username and password](/tutorials/username-and-password) tutorial. Keep in mind that email-based auth requires more than just passwords!
 
 ## Update database
 
@@ -15,7 +15,7 @@ Add a unique `email` and `hashed_password` column to the user table.
 | `email`           | `string` | unique     |
 | `hashed_password` | `string` |            |
 
-Declare the type with `DatabaseUserAttributes` and add the attributes the user object using the `getUserAttributes()` configuration.
+Declare the type with `DatabaseUserAttributes` and add the attributes to the user object using the `getUserAttributes()` configuration.
 
 ```ts
 // auth.ts

--- a/docs/pages/guides/email-and-password/index.md
+++ b/docs/pages/guides/email-and-password/index.md
@@ -4,7 +4,7 @@ title: "Email and password"
 
 # Email and password
 
-Email based auth requires a lot of components so be prepared to do some work! For a step-by-step, framework specific tutorial to learn the basics of password based auth and Lucia, see the [Username and password](/tutorials/username-and-password) tutorial.
+Email-based auth requires a lot of components so be prepared to do some work! For a step-by-step, framework-specific tutorial to learn the basics of password-based auth and Lucia, see the [Username and password](/tutorials/username-and-password) tutorial.
 
 - [Password basics](/guides/email-and-password/basics)
 - Email verification

--- a/docs/pages/guides/oauth/basics.md
+++ b/docs/pages/guides/oauth/basics.md
@@ -4,7 +4,7 @@ title: "OAuth basics"
 
 # OAuth basics
 
-For a step-by-step, framework specific tutorial, see the [GitHub OAuth](/tutorials) tutorial.
+For a step-by-step, framework-specific tutorial, see the [GitHub OAuth](/tutorials) tutorial.
 
 We recommend using [Arctic](https://github.com/pilcrowonpaper/arctic) for implementing OAuth 2.0. It is a lightweight library that provides APIs for creating authorization URLs, validating callbacks, and refreshing access tokens. This is the easiest way to implement OAuth with Lucia and it supports most major providers. This page will use GitHub, and while most providers have similar APIs, there might be some minor differences between them.
 
@@ -23,7 +23,7 @@ Add a `username` and a unique `github_id` column to the user table.
 | `username`  | `string` |            |
 | `github_id` | `number` | unique     |
 
-Declare the type with `DatabaseUserAttributes` and add the attributes the user object using the `getUserAttributes()` configuration.
+Declare the type with `DatabaseUserAttributes` and add the attributes to the user object using the `getUserAttributes()` configuration.
 
 ```ts
 // auth.ts
@@ -81,7 +81,7 @@ app.get("/login/github", async (): Promise<Response> => {
 		status: 302,
 		headers: {
 			Location: url.toString(),
-			"Set-Cookie": serializeCookie("oauth_state", state, {
+			"Set-Cookie": serializeCookie("github_oauth_state", state, {
 				httpOnly: true,
 				secure: env === "PRODUCTION", // set `Secure` flag in HTTPS
 				maxAge: 60 * 10, // 10 minutes
@@ -100,7 +100,7 @@ You can now create a sign in button with just an anchor tag.
 
 ## Validate callback
 
-In the callback route, first get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw a [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID and create a new user if not. Finally, create a new session and set the session cookie.
+In the callback route, first get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
 
 ```ts
 import { github, lucia } from "./auth.js";
@@ -110,7 +110,7 @@ import { parseCookies } from "oslo/cookie";
 
 app.get("/login/github/callback", async (request: Request): Promise<Response> => {
 	const cookies = parseCookies(request.headers.get("Cookie") ?? "");
-	const stateCookie = cookies.get("oauth_state") ?? null;
+	const stateCookie = cookies.get("github_oauth_state") ?? null;
 
 	const url = new URL(request.url);
 	const state = url.searchParams.get("state");

--- a/docs/pages/guides/oauth/index.md
+++ b/docs/pages/guides/oauth/index.md
@@ -6,7 +6,7 @@ title: "OAuth"
 
 OAuth, or social sign in, is the easiest way to implement authentication as you won't have to worry about email verification, passwords, and two-factor authorization.
 
-For a step-by-step, framework specific tutorial, see the [GitHub OAuth](/tutorials/github-oauth) tutorial.
+For a step-by-step, framework-specific tutorial, see the [GitHub OAuth](/tutorials/github-oauth) tutorial.
 
 - [OAuth basics](/guides/oauth/basics)
 - [Multiple OAuth providers](/guides/oauth/multiple-providers)

--- a/docs/pages/guides/oauth/multiple-providers.md
+++ b/docs/pages/guides/oauth/multiple-providers.md
@@ -30,7 +30,7 @@ We can then remove the `github_id` column etc from the user table.
 
 ## Validating callback
 
-Instead of the user table, we can now use the OAuth account table to check if a user is already registered. If not, in an transaction, create the user and OAuth account.
+Instead of the user table, we can now use the OAuth account table to check if a user is already registered. If not, in a transaction, create the user and OAuth account.
 
 ```ts
 const tokens = await githubAuth.validateAuthorizationCode(code);

--- a/docs/pages/guides/oauth/pkce.md
+++ b/docs/pages/guides/oauth/pkce.md
@@ -21,7 +21,7 @@ app.get("/login/twitter", async (): Promise<Response> => {
 	const headers = new Headers();
 	headers.append(
 		"Set-Cookie",
-		serializeCookie("state", state, {
+		serializeCookie("twitter_oauth_state", state, {
 			httpOnly: true,
 			secure: env === "PRODUCTION", // set `Secure` flag in HTTPS
 			maxAge: 60 * 10, // 10 minutes
@@ -52,7 +52,7 @@ import { parseCookies } from "oslo/cookie";
 
 app.get("/login/twitter/callback", async (request: Request): Promise<Response> => {
 	const cookies = parseCookies(request.headers.get("Cookie") ?? "");
-	const stateCookie = cookies.get("oauth_state") ?? null;
+	const stateCookie = cookies.get("twitter_oauth_state") ?? null;
 	const codeVerifier = cookies.get("code_verifier") ?? null;
 
 	const url = new URL(request.url);

--- a/docs/pages/guides/troubleshooting.md
+++ b/docs/pages/guides/troubleshooting.md
@@ -8,7 +8,7 @@ Here are some common issues and how to resolve them. Feel free to ask for help i
 
 ## `User` and `Session` are typed as `any`
 
-Make sure you've registered your types. Check the `typeof lucia` is indeed an instance of `Lucia` (not a function that returns `Lucia`) and that there are no TS errors (including `@ts-ignore`) when declaring `Lucia`. `Register` must be an `interface`, not `type`.
+Make sure you've registered your types. Check that the `typeof lucia` is indeed an instance of `Lucia` (not a function that returns `Lucia`) and that there are no TS errors (including `@ts-ignore`) when declaring `Lucia`. `Register` must be an `interface`, not a `type`.
 
 ```ts
 import { Lucia } from "lucia";
@@ -26,7 +26,7 @@ declare module "lucia" {
 
 ## Session cookies are not set in `localhost`
 
-By default, session cookies have a `Secure` flag, which require HTTPS. You can disable it for development with the `sessionCookie.attributes.secure` configuration.
+By default, session cookies have a `Secure` flag, which requires HTTPS. You can disable it for development with the `sessionCookie.attributes.secure` configuration.
 
 ```ts
 import { Lucia } from "lucia";

--- a/docs/pages/guides/validate-session-cookies/astro.md
+++ b/docs/pages/guides/validate-session-cookies/astro.md
@@ -4,7 +4,7 @@ title: "Validate session cookies in Astro"
 
 # Validate session cookies in Astro
 
-**CSRF protection must be implemented when using cookies and forms** This can be easily done by comparing the `Origin` and `Host` header.
+**CSRF protection must be implemented when using cookies and forms.** This can be easily done by comparing the `Origin` and `Host` header.
 
 We recommend creating a middleware to validate requests and store the current user inside `locals`. You can get the cookie name with `Lucia.sessionCookieName` and validate the session cookie with `Lucia.validateSession()`. Make sure to delete the session cookie if it's invalid and create a new session cookie when the expiration gets extended, which is indicated by `Session.fresh`.
 

--- a/docs/pages/guides/validate-session-cookies/express.md
+++ b/docs/pages/guides/validate-session-cookies/express.md
@@ -4,7 +4,7 @@ title: "Validate session cookies in Express"
 
 # Validate session cookies in Express
 
-**CSRF protection must be implemented when using cookies and forms** This can be easily done by comparing the `Origin` and `Host` header.
+**CSRF protection must be implemented when using cookies and forms.** This can be easily done by comparing the `Origin` and `Host` header.
 
 We recommend creating 2 middleware for CSRF protection and validating requests. You can get the cookie with `Lucia.readSessionCookie()` and validate the session cookie with `Lucia.validateSession()`. Make sure to delete the session cookie if it's invalid and create a new session cookie when the expiration gets extended, which is indicated by `Session.fresh`.
 

--- a/docs/pages/guides/validate-session-cookies/hono.md
+++ b/docs/pages/guides/validate-session-cookies/hono.md
@@ -4,7 +4,7 @@ title: "Validate session cookies in Hono"
 
 # Validate session cookies in Hono
 
-**CSRF protection must be implemented when using cookies and forms** This can be easily done by comparing the `Origin` and `Host` header.
+**CSRF protection must be implemented when using cookies and forms.** This can be easily done by comparing the `Origin` and `Host` header.
 
 We recommend creating 2 middleware for CSRF protection and validating requests. You can get the cookie name with `Lucia.sessionCookieName` and validate the session cookie with `Lucia.validateSession()`. Make sure to delete the session cookie if it's invalid and create a new session cookie when the expiration gets extended, which is indicated by `Session.fresh`.
 

--- a/docs/pages/guides/validate-session-cookies/index.md
+++ b/docs/pages/guides/validate-session-cookies/index.md
@@ -16,7 +16,7 @@ This guide is also available for:
 - [SolidStart](/guides/validate-session-cookies/solidstart)
 - [SvelteKit](/guides/validate-session-cookies/sveltekit)
 
-**CSRF protection must be implemented when using cookies and forms** This can be easily done by comparing the `Origin` and `Host` header.
+**CSRF protection must be implemented when using cookies and forms.** This can be easily done by comparing the `Origin` and `Host` header.
 
 For non-GET requests, check the request origin. You can use `readSessionCookie()` to get the session cookie from a HTTP `Cookie` header, and validate it with `Lucia.validateSession()`. Make sure to delete the session cookie if it's invalid and create a new session cookie when the expiration gets extended, which is indicated by `Session.fresh`.
 

--- a/docs/pages/guides/validate-session-cookies/nextjs-app.md
+++ b/docs/pages/guides/validate-session-cookies/nextjs-app.md
@@ -74,7 +74,7 @@ async function Page() {
 }
 ```
 
-For API routes, since Next.js do not implement CSRF protection for API routes, **CSRF protection must be implemented when dealing with forms** if you're dealing with forms. This can be easily done by comparing the `Origin` and `Host` header. We recommend using middleware for this.
+For API routes, since Next.js does not implement CSRF protection for API routes, **CSRF protection must be implemented when dealing with forms** if you're dealing with forms. This can be easily done by comparing the `Origin` and `Host` header. We recommend using middleware for this.
 
 ```ts
 // middleware.ts

--- a/docs/pages/guides/validate-session-cookies/nuxt.md
+++ b/docs/pages/guides/validate-session-cookies/nuxt.md
@@ -4,7 +4,7 @@ title: "Validate session cookies in Nuxt"
 
 # Validate session cookies in Nuxt
 
-**CSRF protection must be implemented when using cookies and forms** This can be easily done by comparing the `Origin` and `Host` header.
+**CSRF protection must be implemented when using cookies and forms.** This can be easily done by comparing the `Origin` and `Host` header.
 
 We recommend creating a middleware to validate requests and store the current user inside `context`. You can get the cookie name with `Lucia.sessionCookieName` and validate the session cookie with `Lucia.validateSession()`. Make sure to delete the session cookie if it's invalid and create a new session cookie when the expiration gets extended, which is indicated by `Session.fresh`.
 

--- a/docs/pages/guides/validate-session-cookies/solidstart.md
+++ b/docs/pages/guides/validate-session-cookies/solidstart.md
@@ -4,7 +4,7 @@ title: "Validate session cookies in SolidStart"
 
 # Validate session cookies in SolidStart
 
-**CSRF protection must be implemented when using cookies and forms** This can be easily done by comparing the `Origin` and `Host` header.
+**CSRF protection must be implemented when using cookies and forms.** This can be easily done by comparing the `Origin` and `Host` header.
 
 We recommend creating a middleware to validate requests and store the current user inside `context`. You can get the cookie name with `Lucia.sessionCookieName` and validate the session cookie with `Lucia.validateSession()`. Make sure to delete the session cookie if it's invalid and create a new session cookie when the expiration gets extended, which is indicated by `Session.fresh`.
 

--- a/docs/pages/reference/main/Lucia/index.md
+++ b/docs/pages/reference/main/Lucia/index.md
@@ -40,7 +40,7 @@ function constructor<
 
 - `adapter`: Database adapter
 - `options`:
-  - `sessionExpiresIn`: How long a session lasts for maximum for inactive users
+  - `sessionExpiresIn`: How long a session lasts for inactive users
   - `sessionCookie`: Session cookie options
     - `name`: Cookie name (default: `auth_session`)
     - `expires`: Set to `false` for cookies to persist indefinitely (default: `true`)

--- a/docs/pages/tutorials/github-oauth/astro.md
+++ b/docs/pages/tutorials/github-oauth/astro.md
@@ -4,7 +4,7 @@ title: "GitHub OAuth in Astro"
 
 # Tutorial: GitHub OAuth in Astro
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/astro) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/astro) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/astro/github-oauth) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/astro/github-oauth).
 
@@ -126,7 +126,7 @@ export async function GET(context: APIContext): Promise<Response> {
 
 ## Validate callback
 
-Create an API route in `pages/login/github/callback.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw a [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID and create a new user if not. Finally, create a new session and set the session cookie.
+Create an API route in `pages/login/github/callback.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
 
 ```ts
 // pages/login/github/callback.ts

--- a/docs/pages/tutorials/github-oauth/index.md
+++ b/docs/pages/tutorials/github-oauth/index.md
@@ -4,7 +4,7 @@ title: "Tutorial: GitHub OAuth"
 
 # Tutorial: GitHub OAuth
 
-The tutorials go over how to implement a basic GitHub OAuth and covers the basics of Lucia along the way. As a prerequisite, you should be fairly comfortable with your framework and its APIs. Basic example projects are available in the [examples repository](https://github.com/lucia-auth/examples/tree/v3).
+The tutorials go over how to implement a basic GitHub OAuth and cover the basics of Lucia along the way. As a prerequisite, you should be fairly comfortable with your framework and its APIs. Basic example projects are available in the [examples repository](https://github.com/lucia-auth/examples/tree/v3).
 
 - [Astro](/tutorials/github-oauth/astro)
 - [Next.js App router](/tutorials/github-oauth/nextjs-app)

--- a/docs/pages/tutorials/github-oauth/nextjs-app.md
+++ b/docs/pages/tutorials/github-oauth/nextjs-app.md
@@ -4,7 +4,7 @@ title: "GitHub OAuth in Next.js App router"
 
 # Tutorial: GitHub OAuth in Next.js App router
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/nextjs-app) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/nextjs-app) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/nextjs-app/github-oauth) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/nextjs-app/github-oauth).
 
@@ -125,7 +125,7 @@ export async function GET(): Promise<Response> {
 
 ## Validate callback
 
-Create an API route in `app/login/github/callback/route.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw a [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID and create a new user if not. Finally, create a new session and set the session cookie.
+Create an API route in `app/login/github/callback/route.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
 
 ```ts
 // app/login/github/callback/route.ts
@@ -204,7 +204,7 @@ interface GitHubUser {
 
 ## Validate requests
 
-Create `validateRequest()`. This will check for the session cookie, validates it, and sets a new cookie if necessary. Make sure to catch errors when setting cookies and wrap the function with `cache()` to prevent unnecessary database calls. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-app) page.
+Create `validateRequest()`. This will check for the session cookie, validate it, and set a new cookie if necessary. Make sure to catch errors when setting cookies and wrap the function with `cache()` to prevent unnecessary database calls. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-app) page.
 
 CSRF protection should be implemented but Next.js handles it when using form actions (but not for API routes).
 

--- a/docs/pages/tutorials/github-oauth/nextjs-pages.md
+++ b/docs/pages/tutorials/github-oauth/nextjs-pages.md
@@ -4,7 +4,7 @@ title: "GitHub OAuth in Next.js Pages router"
 
 # Tutorial: GitHub OAuth in Next.js Pages router
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/nextjs-pages) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/nextjs-pages) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/nextjs-pages/github-oauth) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/nextjs-pages/github-oauth).
 
@@ -132,7 +132,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 ## Validate callback
 
-Create an API route in `pages/api/login/github/callback.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw a [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID and create a new user if not. Finally, create a new session and set the session cookie.
+Create an API route in `pages/api/login/github/callback.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
 
 ```ts
 // pages/api/login/github/callback.ts
@@ -203,7 +203,7 @@ interface GitHubUser {
 
 ## Validate requests
 
-Create `validateRequest()`. This will check for the session cookie, validates it, and sets a new cookie if necessary. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-pages) page.
+Create `validateRequest()`. This will check for the session cookie, validate it, and set a new cookie if necessary. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-pages) page.
 
 CSRF protection should be implemented and you should already have a middleware for it.
 

--- a/docs/pages/tutorials/github-oauth/nuxt.md
+++ b/docs/pages/tutorials/github-oauth/nuxt.md
@@ -4,7 +4,7 @@ title: "GitHub OAuth in Nuxt"
 
 # Tutorial: GitHub OAuth in Nuxt
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/nuxt) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/nuxt) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/nuxt/github-oauth) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/nuxt/github-oauth).
 
@@ -118,7 +118,7 @@ export default defineEventHandler(async (event) => {
 
 ## Validate callback
 
-Create an API route in `server/routes/login/github/callback.get.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw a [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID and create a new user if not. Finally, create a new session and set the session cookie.
+Create an API route in `server/routes/login/github/callback.get.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
 
 ```ts
 // server/routes/login/github/callback.get.ts

--- a/docs/pages/tutorials/github-oauth/sveltekit.md
+++ b/docs/pages/tutorials/github-oauth/sveltekit.md
@@ -4,7 +4,7 @@ title: "GitHub OAuth in SvelteKit"
 
 # Tutorial: GitHub OAuth in SvelteKit
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/sveltekit) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/sveltekit) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/sveltekit/github-oauth) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/sveltekit/github-oauth).
 
@@ -124,7 +124,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
 
 ## Validate callback
 
-Create an API route in `routes/login/github/callback/+server.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw a [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID and create a new user if not. Finally, create a new session and set the session cookie.
+Create an API route in `routes/login/github/callback/+server.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
 
 ```ts
 // routes/login/github/callback/+server.ts

--- a/docs/pages/tutorials/username-and-password/astro.md
+++ b/docs/pages/tutorials/username-and-password/astro.md
@@ -4,7 +4,7 @@ title: "Tutorial: Username and password auth in Astro"
 
 # Tutorial: Username and password auth in Astro
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/astro) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/astro) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/astro/username-and-password) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/astro/username-and-password).
 
@@ -72,7 +72,7 @@ Create `pages/signup.astro` and set up a basic form.
 </html>
 ```
 
-Create an API route in `pages/api/signup.ts`. First do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route in `pages/api/signup.ts`. First, do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // pages/api/signup.ts
@@ -156,7 +156,7 @@ Create `pages/login.astro` and set up a basic form.
 </html>
 ```
 
-Create an API route as `pages/api/signup.ts`. First do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route as `pages/api/signup.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // pages/api/login.ts

--- a/docs/pages/tutorials/username-and-password/index.md
+++ b/docs/pages/tutorials/username-and-password/index.md
@@ -4,7 +4,7 @@ title: "Tutorial: Username and password"
 
 # Tutorial: Username and password auth
 
-The tutorials go over how to implement a basic username and password auth and covers the basics of Lucia along the way. As a prerequisite, you should be fairly comfortable with your framework and its APIs. For a more in-depth guide, see the [Email and password](/guides/email-and-password/) guides. Basic example projects are available in the [examples repository](https://github.com/lucia-auth/examples/tree/v3).
+The tutorials go over how to implement a basic username and password auth and cover the basics of Lucia along the way. As a prerequisite, you should be fairly comfortable with your framework and its APIs. For a more in-depth guide, see the [Email and password](/guides/email-and-password/) guides. Basic example projects are available in the [examples repository](https://github.com/lucia-auth/examples/tree/v3).
 
 - [Astro](/tutorials/username-and-password/astro)
 - [Next.js App router](/tutorials/username-and-password/nextjs-app)

--- a/docs/pages/tutorials/username-and-password/nextjs-app.md
+++ b/docs/pages/tutorials/username-and-password/nextjs-app.md
@@ -4,7 +4,7 @@ title: "Username and password auth in Next.js App Router"
 
 # Username and password auth in Next.js App Router
 
-Before starting, make sure you've setup your database as described in the [Getting started](/getting-started/nextjs-app) page.
+Before starting, make sure you've set up your database as described in the [Getting started](/getting-started/nextjs-app) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/nextjs-app/username-and-password) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/nextjs-app/username-and-password).
 
@@ -233,7 +233,7 @@ async function login(_: any, formData: FormData): Promise<ActionResult> {
 
 ## Validate requests
 
-Create `validateRequest()`. This will check for the session cookie, validates it, and sets a new cookie if necessary. Make sure to catch errors when setting cookies and wrap the function with `cache()` to prevent unnecessary database calls. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-app) page.
+Create `validateRequest()`. This will check for the session cookie, validate it, and set a new cookie if necessary. Make sure to catch errors when setting cookies and wrap the function with `cache()` to prevent unnecessary database calls. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-app) page.
 
 CSRF protection should be implemented but Next.js handles it when using form actions (but not for API routes).
 

--- a/docs/pages/tutorials/username-and-password/nextjs-pages.md
+++ b/docs/pages/tutorials/username-and-password/nextjs-pages.md
@@ -4,7 +4,7 @@ title: "Tutorial: Username and password auth in Next.js Pages router"
 
 # Tutorial: Username and password auth in Next.js Pages router
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/nextjs-pages) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/nextjs-pages) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/nextjs-pages/username-and-password) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/nextjs-pages/username-and-password).
 
@@ -96,7 +96,7 @@ export default function Page() {
 }
 ```
 
-Create an API route in `pages/api/signup.ts`. First do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route in `pages/api/signup.ts`. First, do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // pages/api/signup.ts
@@ -204,7 +204,7 @@ export default function Page() {
 }
 ```
 
-Create an API route as `pages/api/signup.ts`. First do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route as `pages/api/signup.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // pages/api/login.ts
@@ -264,7 +264,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 ## Validate requests
 
-Create `validateRequest()`. This will check for the session cookie, validates it, and sets a new cookie if necessary. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-pages) page.
+Create `validateRequest()`. This will check for the session cookie, validate it, and set a new cookie if necessary. To learn more, see the [Validating requests](/basics/validate-session-cookies/nextjs-pages) page.
 
 CSRF protection should be implemented and you should already have a middleware for it.
 

--- a/docs/pages/tutorials/username-and-password/nuxt.md
+++ b/docs/pages/tutorials/username-and-password/nuxt.md
@@ -4,7 +4,7 @@ title: "Tutorial: Username and password auth in Nuxt"
 
 # Tutorial: Username and password auth in Nuxt
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/nuxt) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/nuxt) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/nuxt/username-and-password) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/nuxt/username-and-password).
 
@@ -85,7 +85,7 @@ async function signup(e: Event) {
 </template>
 ```
 
-Create an API route in `server/api/signup.post.ts`. First do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route in `server/api/signup.post.ts`. First, do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // server/api/signup.post.ts
@@ -176,7 +176,7 @@ async function login(e: Event) {
 </template>
 ```
 
-Create an API route as `server/api/login.post.ts`. First do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route as `server/api/login.post.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // server/api/login.post.ts

--- a/docs/pages/tutorials/username-and-password/sveltekit.md
+++ b/docs/pages/tutorials/username-and-password/sveltekit.md
@@ -4,7 +4,7 @@ title: "Tutorial: Username and password auth in SvelteKit"
 
 # Tutorial: Username and password auth in SvelteKit
 
-Before starting, make sure you've setup your database and middleware as described in the [Getting started](/getting-started/astro) page.
+Before starting, make sure you've set up your database and middleware as described in the [Getting started](/getting-started/astro) page.
 
 An [example project](https://github.com/lucia-auth/examples/tree/v3/sveltekit/username-and-password) based on this tutorial is also available. You can clone the example locally or [open it in StackBlitz](https://stackblitz.com/github/lucia-auth/examples/tree/v3/sveltekit/username-and-password).
 
@@ -73,7 +73,7 @@ Create `routes/signup/+page.svelte` and set up a basic form.
 </form>
 ```
 
-Create a form action in `routes/signup/+page.server.ts`. First do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create a form action in `routes/signup/+page.server.ts`. First, do a very basic input validation. Hash the password, generate a new user ID, and create a new user. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // routes/signup/+page.server.ts
@@ -162,7 +162,7 @@ Create `routes/login/+page.svelte` and set up a basic form.
 </form>
 ```
 
-Create an API route as `pages/api/signup.ts`. First do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route as `pages/api/signup.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 import { lucia } from "$lib/server/auth";

--- a/docs/pages/upgrade-v3/index.md
+++ b/docs/pages/upgrade-v3/index.md
@@ -4,15 +4,15 @@ title: "Upgrade to Lucia v3"
 
 # Upgrade to Lucia v3
 
-Version 3.0 rethinks Lucia and the role it should play into your application. We have stripped out all the annoying bits, and everything else we kept has been refined even more. Everything is more flexible, and just all around easier to understand and work with.
+Version 3.0 rethinks Lucia and the role it should play in your application. We have stripped out all the annoying bits, and everything else we kept has been refined even more. Everything is more flexible, and just all around easier to understand and work with.
 
 We estimate it will take about an hour or two to upgrade your project, though it depends on how big your application is. If you're having issues with the migration or have any questions, feel free to ask on our [Discord server](https://discord.com/invite/PwrK3kpVR3).
 
 ## Major changes
 
-The biggest change to Lucia is that keys have been removed entirely. We believe it was too limiting and ultimately an unnecessary concept that made many projects more complex than it needed to be. Another big change is that Lucia no longer handles user creation, so `createUser()` among other APIs have been removed.
+The biggest change to Lucia is that keys have been removed entirely. We believe it was too limiting and ultimately an unnecessary concept that made many projects more complex than they needed to be. Another big change is that Lucia no longer handles user creation, so `createUser()` among other APIs has been removed.
 
-For a simple password based auth, the password can just be stored in the user table.
+For a simple password-based auth, the password can just be stored in the user table.
 
 ```ts
 const hashedPassword = await new Argon2id().hash(password);
@@ -50,7 +50,7 @@ export const lucia = new Lucia(adapter, {
 });
 ```
 
-Here's the fully updated configuration for reference. `middleware` and `csrfProtection` has been removed.
+Here's the fully updated configuration for reference. `middleware` and `csrfProtection` have been removed.
 
 ```ts
 import { Lucia, TimeSpan } from "lucia";
@@ -129,13 +129,13 @@ The following packages are deprecated:
 - `@lucia-auth/adapter-session-redis`
 - `@lucia-auth/adapter-session-unstorage`
 
-If you're using a session adapter, we recommend building a custom adapter as the API have been greatly simplified.
+If you're using a session adapter, we recommend building a custom adapter as the API has been greatly simplified.
 
 ## Sessions
 
 ### Session validation
 
-Middleware, `Auth.handleRequest()`, and `AuthRequest` have been removed. **This means Lucia no longer provides strict CSRF protection**. For replacing `AuthRequest.validate()`, see the [Validating session cookies](/guides/validate-session-cookies) guide or a framework specific version of it as these need to be re-implemented from scratch (though it's just copy-pasting code from the guides):
+Middleware, `Auth.handleRequest()`, and `AuthRequest` have been removed. **This means Lucia no longer provides strict CSRF protection**. For replacing `AuthRequest.validate()`, see the [Validating session cookies](/guides/validate-session-cookies) guide or a framework-specific version of it as these need to be re-implemented from scratch (though it's just copy-pasting code from the guides):
 
 - [Astro](/guides/validate-session-cookies/astro)
 - [Elysia](/guides/validate-session-cookies/elysia)

--- a/docs/pages/upgrade-v3/mysql.md
+++ b/docs/pages/upgrade-v3/mysql.md
@@ -32,7 +32,7 @@ new PlanetScaleAdapter(connection, {
 
 ## Update session table
 
-The main changes to the session table is that `idle_expires` and `active_expires` columns are replaced with a single `expires_at` column. Unlike the previous columns, it's a `DATETIME` column.
+The main change to the session table is that the `idle_expires` and `active_expires` columns are replaced with a single `expires_at` column. Unlike the previous columns, it's a `DATETIME` column.
 
 **Check your table names before running the code.**
 
@@ -67,7 +67,7 @@ WHERE hashed_password IS NULL;
 
 ### Email/password
 
-The SQL below creates a dedicated table `password` for storing user passwords. This assumes the provider id for emails was `email` and that you're already storing the users' emails in the user table.
+The SQL below creates a dedicated table `password` for storing user passwords. This assumes the provider ID for emails was `email` and that you're already storing the users' emails in the user table.
 
 ```sql
 CREATE TABLE password (

--- a/docs/pages/upgrade-v3/oauth.md
+++ b/docs/pages/upgrade-v3/oauth.md
@@ -10,7 +10,7 @@ You can continue using the keys table but we recommend creating a dedicated tabl
 
 ## Replace OAuth integration
 
-The OAuth integration has been replaced with [Arctic](https://github.com/pilcrowonpaper/arctic), which provides everything the integration did without Lucia specific APIs. It supports all the OAuth providers that the integration supported.
+The OAuth integration has been replaced with [Arctic](https://github.com/pilcrowonpaper/arctic), which provides everything the integration did without Lucia-specific APIs. It supports all the OAuth providers that the integration supported.
 
 ```
 npm install arctic
@@ -57,7 +57,7 @@ setCookie("github_oauth_state", state, {
 
 The `state` check stays the same.
 
-`validateAuthorizationCode()` replaces `validateCallback()`. Instead of returning tokens, users, and database methods, it just returns tokens. Use the access token to get the user, check if the user is already registered, and create a new user if not.
+`validateAuthorizationCode()` replaces `validateCallback()`. Instead of returning tokens, users, and database methods, it just returns tokens. Use the access token to get the user, then check if the user is already registered and create a new user if they aren't.
 
 You now have to create users and manage OAuth accounts by yourself.
 
@@ -80,7 +80,7 @@ const existingAccount = await db
 	.get();
 
 if (existingAccount) {
-	// simplified `createSession()` - seconds params for session attributes
+	// simplified `createSession()` - second param for session attributes
 	const session = await lucia.createSession(existingUser.id, {});
 
 	// `createSessionCookie()` now takes a session ID instead of the entire session object
@@ -96,7 +96,7 @@ if (existingAccount) {
 	});
 }
 
-// v2 IDs have length of 15
+// v2 IDs have a length of 15
 const userId = generateId(15);
 
 await db.beginTransaction();
@@ -113,7 +113,7 @@ await db.table("oauth_account").insert({
 });
 await db.commit();
 
-// simplified `createSession()` - seconds params for session attributes
+// simplified `createSession()` - second param for session attributes
 const session = await lucia.createSession(userId, {});
 // `createSessionCookie()` now takes a session ID instead of the entire session object
 const sessionCookie = lucia.createSessionCookie(session.id);
@@ -129,7 +129,7 @@ return new Response(null, {
 
 ### Error handling
 
-Error handling has improved with v3. `validateAuthorizationCode()` throws `OAuth2RequestError`, which includes proper error messages and descriptions.
+Error handling has improved with v3. `validateAuthorizationCode()` throws an `OAuth2RequestError`, which includes proper error messages and descriptions.
 
 ```ts
 try {

--- a/docs/pages/upgrade-v3/password.md
+++ b/docs/pages/upgrade-v3/password.md
@@ -15,7 +15,7 @@ Lucia provides `LegacyScrypt` for hashing and comparing passwords using the algo
 ```ts
 import { generateId, LegacyScrypt } from "lucia";
 
-// v2 IDs have length of 15
+// v2 IDs have a length of 15
 const userId = generateId(15);
 
 await db.beginTransaction();
@@ -31,7 +31,7 @@ await db.table("password").insert({
 });
 await db.commit();
 
-// simplified `createSession()` - seconds params for session attributes
+// simplified `createSession()` - second param for session attributes
 const session = await lucia.createSession(userId, {});
 // `createSessionCookie()` now takes a session ID instead of the entire session object
 const sessionCookie = lucia.createSessionCookie(session.id);

--- a/docs/pages/upgrade-v3/postgresql.md
+++ b/docs/pages/upgrade-v3/postgresql.md
@@ -34,7 +34,7 @@ new PostgresJsAdapter(sql, {
 
 ## Update session table
 
-The main changes to the session table is that `idle_expires` and `active_expires` columns are replaced with a single `expires_at` column. Unlike the previous columns, it's a `DATETIME` column.
+The main change to the session table is that the `idle_expires` and `active_expires` columns are replaced with a single `expires_at` column. Unlike the previous columns, it's a `DATETIME` column.
 
 **Check your table names before running the code.**
 
@@ -80,7 +80,7 @@ WHERE hashed_password IS NULL;
 
 ### Email/password
 
-The SQL below creates a dedicated table `password` for storing user passwords. This assumes the provider id for emails was `email` and that you're already storing the users' emails in the user table.
+The SQL below creates a dedicated table `password` for storing user passwords. This assumes the provider ID for emails was `email` and that you're already storing the users' emails in the user table.
 
 ```sql
 CREATE TABLE password (

--- a/docs/pages/upgrade-v3/prisma/mysql.md
+++ b/docs/pages/upgrade-v3/prisma/mysql.md
@@ -8,7 +8,7 @@ The v3 Prisma adapter now requires all fields to be `camelCase`.
 
 ## Update session table
 
-The main changes to the session table is that `idle_expires` and `active_expires` fields are replaced with a single `expiresAt` field. Unlike the previous columns, it's a `DateTime` type. Update the `Session` model. Make sure to add any custom attributes you previously had.
+The main change to the session table is that the `idle_expires` and `active_expires` fields are replaced with a single `expiresAt` field. Unlike the previous columns, it's a `DateTime` type. Update the `Session` model. Make sure to add any custom attributes you previously had.
 
 ```prisma
 model Session {
@@ -114,7 +114,7 @@ Update your database:
 npx prisma migrate dev --name added_password_table
 ```
 
-Finally, copy the data from the key table. This assumes the provider id for emails was `email` and that you're already storing the users' emails in the user table.
+Finally, copy the data from the key table. This assumes the provider ID for emails was `email` and that you're already storing the users' emails in the user table.
 
 ```sql
 INSERT INTO Password (`hashedPassword`, `userId`)

--- a/docs/pages/upgrade-v3/prisma/postgresql.md
+++ b/docs/pages/upgrade-v3/prisma/postgresql.md
@@ -8,7 +8,7 @@ The v3 Prisma adapter now requires all fields to be `camelCase`.
 
 ## Update session table
 
-The main changes to the session table is that `idle_expires` and `active_expires` fields are replaced with a single `expiresAt` field. Unlike the previous columns, it's a `DateTime` type. Update the `Session` model. Make sure to add any custom attributes you previously had.
+The main change to the session table is that the `idle_expires` and `active_expires` fields are replaced with a single `expiresAt` field. Unlike the previous columns, it's a `DateTime` type. Update the `Session` model. Make sure to add any custom attributes you previously had.
 
 ```prisma
 model Session {
@@ -117,7 +117,7 @@ Update your database:
 npx prisma migrate dev --name added_password_table
 ```
 
-Finally, copy the data from the key table. This assumes the provider id for emails was `email` and that you're already storing the users' emails in the user table.
+Finally, copy the data from the key table. This assumes the provider ID for emails was `email` and that you're already storing the users' emails in the user table.
 
 ```sql
 INSERT INTO "Password" ("hashedPassword", "userId")

--- a/docs/pages/upgrade-v3/prisma/sqlite.md
+++ b/docs/pages/upgrade-v3/prisma/sqlite.md
@@ -8,7 +8,7 @@ The v3 Prisma adapter now requires all fields to be `camelCase`.
 
 ## Update session table
 
-The main changes to the session table is that `idle_expires` and `active_expires` fields are replaced with a single `expiresAt` field. Unlike the previous columns, it's a `DateTime` type. Update the `Session` model. Make sure to add any custom attributes you previously had.
+The main change to the session table is that the `idle_expires` and `active_expires` fields are replaced with a single `expiresAt` field. Unlike the previous columns, it's a `DateTime` type. Update the `Session` model. Make sure to add any custom attributes you previously had.
 
 ```prisma
 model Session {
@@ -116,7 +116,7 @@ Update your database:
 npx prisma migrate dev --name added_password_table
 ```
 
-Finally, copy the data from the key table. This assumes the provider id for emails was `email` and that you're already storing the users' emails in the user table.
+Finally, copy the data from the key table. This assumes the provider ID for emails was `email` and that you're already storing the users' emails in the user table.
 
 ```sql
 INSERT INTO "Password" ("hashedPassword", "userId")

--- a/docs/pages/upgrade-v3/sqlite.md
+++ b/docs/pages/upgrade-v3/sqlite.md
@@ -42,7 +42,7 @@ new LibSQLAdapter(db, {
 
 ## Update session table
 
-The main changes to the session table is that `idle_expires` and `active_expires` columns are replaced with a single `expires_at` column. Unlike the previous columns, this takes a UNIX time in _seconds_.
+The main change to the session table is that the `idle_expires` and `active_expires` columns are replaced with a single `expires_at` column. Unlike the previous columns, this takes a UNIX time in _seconds_.
 
 Make sure to use transactions and add any additional columns in your existing session table when creating the new table and copying the data.
 
@@ -94,7 +94,7 @@ WHERE hashed_password IS NULL;
 
 ### Email/password
 
-The SQL below creates a dedicated table `password` for storing user passwords. This assumes the provider id for emails was `email` and that you're already storing the users' emails in the user table.
+The SQL below creates a dedicated table `password` for storing user passwords. This assumes the provider ID for emails was `email` and that you're already storing the users' emails in the user table.
 
 ```sql
 CREATE TABLE password (
@@ -107,7 +107,7 @@ SELECT hashed_password, user_id FROM key
 WHERE substr(id, 1, instr(id, ':')-1) = 'email';
 ```
 
-Alternatively, you can store the user's credentials in the user table if you only work with email/password. Unfortunately, since SQLite's `ALTER` statement only supports a limited number of operations, you'd have to recreate tables that references the user table.
+Alternatively, you can store the user's credentials in the user table if you only work with email/password. Unfortunately, since SQLite's `ALTER` statement only supports a limited number of operations, you'd have to recreate tables that reference the user table.
 
 ```sql
 BEGIN TRANSACTION;


### PR DESCRIPTION
Some suggestions for the new docs. Some of these changes are opinionated, and some may be incorrect or unwanted, so let me know if I should revert or update any of these suggested changes.

Also, I noticed that in some parts of the docs `oauth_state` was used for the name of the cookie, and in other parts `<provider>_oauth_state` was used (e.g. `github_oauth_state`), so I thought it might be good to make the docs more consistent by always using the `<provider>_oauth_state` format, but let me know if you'd rather keep it how it was before.