### PR TITLE
Fix Atlassian provider

### DIFF
--- a/.auri/$ygs60su4.md
+++ b/.auri/$ygs60su4.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/oauth"
+type: "patch"
+---
+
+Fixed the endpoint used for exchanging authorization codes for the Atlassian provider

--- a/packages/oauth/src/providers/atlassian.ts
+++ b/packages/oauth/src/providers/atlassian.ts
@@ -67,7 +67,7 @@ export class AtlassianAuth<
 			access_token: string;
 			expires_in: number;
 			refresh_token?: string;
-		}>(code, "https://auth.atlassian.com/token", {
+		}>(code, "https://auth.atlassian.com/oauth/token", {
 			clientId: this.config.clientId,
 			redirectUri: this.config.redirectUri,
 			clientPassword: {


### PR DESCRIPTION
Now using the correct endpoint to exchange the authorization code.
Closes #1352 