### PR TITLE
make user id type to be infer from adapter

### DIFF
--- a/packages/adapter-mongodb/src/index.ts
+++ b/packages/adapter-mongodb/src/index.ts
@@ -19,7 +19,8 @@ interface SessionDoc extends RegisteredDatabaseSessionAttributes {
 	expires_at: Date;
 }
 
-export class MongodbAdapter implements Adapter {
+// Mongodb's _id might be string
+export class MongodbAdapter implements Adapter<string> {
 	private Session: Collection<SessionDoc>;
 	private User: Collection<UserDoc>;
 
@@ -38,7 +39,7 @@ export class MongodbAdapter implements Adapter {
 
 	public async getSessionAndUser(
 		sessionId: string
-	): Promise<[session: DatabaseSession | null, user: DatabaseUser | null]> {
+	): Promise<[session: DatabaseSession<string> | null, user: DatabaseUser<string> | null]> {
 		const sessionUsers = await this.Session.aggregate([
 			{ $match: { _id: sessionId } },
 			{
@@ -64,7 +65,7 @@ export class MongodbAdapter implements Adapter {
 		return [session, user];
 	}
 
-	public async getUserSessions(userId: string): Promise<DatabaseSession[]> {
+	public async getUserSessions(userId: string): Promise<DatabaseSession<string>[]> {
 		const sessions = await this.Session.find(
 			{ user_id: userId },
 			{
@@ -80,7 +81,7 @@ export class MongodbAdapter implements Adapter {
 		return sessions.map((val) => transformIntoDatabaseSession(val));
 	}
 
-	public async setSession(session: DatabaseSession): Promise<void> {
+	public async setSession(session: DatabaseSession<string>): Promise<void> {
 		const value: SessionDoc = {
 			_id: session.id,
 			user_id: session.userId,
@@ -104,7 +105,7 @@ export class MongodbAdapter implements Adapter {
 	}
 }
 
-function transformIntoDatabaseUser(value: UserDoc): DatabaseUser {
+function transformIntoDatabaseUser(value: UserDoc): DatabaseUser<string> {
 	delete value.__v;
 	const { _id: id, ...attributes } = value;
 	return {
@@ -113,7 +114,7 @@ function transformIntoDatabaseUser(value: UserDoc): DatabaseUser {
 	};
 }
 
-function transformIntoDatabaseSession(value: SessionDoc): DatabaseSession {
+function transformIntoDatabaseSession(value: SessionDoc): DatabaseSession<string> {
 	delete value.__v;
 	const { _id: id, user_id: userId, expires_at: expiresAt, ...attributes } = value;
 	return {

--- a/packages/adapter-mysql/src/base.ts
+++ b/packages/adapter-mysql/src/base.ts
@@ -6,7 +6,7 @@ import type {
 	RegisteredDatabaseUserAttributes
 } from "lucia";
 
-export class MySQLAdapter implements Adapter {
+export class MySQLAdapter<TUserId> implements Adapter<TUserId> {
 	private controller: Controller;
 
 	private escapedUserTableName: string;
@@ -24,7 +24,7 @@ export class MySQLAdapter implements Adapter {
 		]);
 	}
 
-	public async deleteUserSessions(userId: string): Promise<void> {
+	public async deleteUserSessions(userId: TUserId): Promise<void> {
 		await this.controller.execute(`DELETE FROM ${this.escapedSessionTableName} WHERE user_id = ?`, [
 			userId
 		]);
@@ -32,7 +32,7 @@ export class MySQLAdapter implements Adapter {
 
 	public async getSessionAndUser(
 		sessionId: string
-	): Promise<[session: DatabaseSession | null, user: DatabaseUser | null]> {
+	): Promise<[session: DatabaseSession<TUserId> | null, user: DatabaseUser<TUserId> | null]> {
 		const [databaseSession, databaseUser] = await Promise.all([
 			this.getSession(sessionId),
 			this.getUserFromSessionId(sessionId)
@@ -40,8 +40,8 @@ export class MySQLAdapter implements Adapter {
 		return [databaseSession, databaseUser];
 	}
 
-	public async getUserSessions(userId: string): Promise<DatabaseSession[]> {
-		const result = await this.controller.getAll<SessionSchema>(
+	public async getUserSessions(userId: TUserId): Promise<DatabaseSession<TUserId>[]> {
+		const result = await this.controller.getAll<SessionSchema<TUserId>>(
 			`SELECT * FROM ${this.escapedSessionTableName} WHERE user_id = ?`,
 			[userId]
 		);
@@ -50,8 +50,8 @@ export class MySQLAdapter implements Adapter {
 		});
 	}
 
-	public async setSession(databaseSession: DatabaseSession): Promise<void> {
-		const value: SessionSchema = {
+	public async setSession(databaseSession: DatabaseSession<TUserId>): Promise<void> {
+		const value: SessionSchema<TUserId> = {
 			id: databaseSession.id,
 			user_id: databaseSession.userId,
 			expires_at: databaseSession.expiresAt,
@@ -83,8 +83,8 @@ export class MySQLAdapter implements Adapter {
 		);
 	}
 
-	private async getSession(sessionId: string): Promise<DatabaseSession | null> {
-		const result = await this.controller.get<SessionSchema>(
+	private async getSession(sessionId: string): Promise<DatabaseSession<TUserId> | null> {
+		const result = await this.controller.get<SessionSchema<TUserId>>(
 			`SELECT * FROM ${this.escapedSessionTableName} WHERE id = ?`,
 			[sessionId]
 		);
@@ -92,8 +92,8 @@ export class MySQLAdapter implements Adapter {
 		return transformIntoDatabaseSession(result);
 	}
 
-	private async getUserFromSessionId(sessionId: string): Promise<DatabaseUser | null> {
-		const result = await this.controller.get<UserSchema>(
+	private async getUserFromSessionId(sessionId: string): Promise<DatabaseUser<TUserId> | null> {
+		const result = await this.controller.get<UserSchema<TUserId>>(
 			`SELECT ${this.escapedUserTableName}.* FROM ${this.escapedSessionTableName} INNER JOIN ${this.escapedUserTableName} ON ${this.escapedUserTableName}.id = ${this.escapedSessionTableName}.user_id WHERE ${this.escapedSessionTableName}.id = ?`,
 			[sessionId]
 		);
@@ -113,17 +113,19 @@ export interface Controller {
 	getAll<T>(sql: string, args?: any[]): Promise<T[]>;
 }
 
-interface SessionSchema extends RegisteredDatabaseSessionAttributes {
+interface SessionSchema<TUserId> extends RegisteredDatabaseSessionAttributes {
 	id: string;
-	user_id: string;
+	user_id: TUserId;
 	expires_at: Date | string;
 }
 
-interface UserSchema extends RegisteredDatabaseUserAttributes {
-	id: string;
+interface UserSchema<TUserId> extends RegisteredDatabaseUserAttributes {
+	id: TUserId;
 }
 
-function transformIntoDatabaseSession(raw: SessionSchema): DatabaseSession {
+function transformIntoDatabaseSession<TUserId>(
+	raw: SessionSchema<TUserId>
+): DatabaseSession<TUserId> {
 	const { id, user_id: userId, expires_at: expiresAtResult, ...attributes } = raw;
 	return {
 		userId,
@@ -134,7 +136,7 @@ function transformIntoDatabaseSession(raw: SessionSchema): DatabaseSession {
 	};
 }
 
-function transformIntoDatabaseUser(raw: UserSchema): DatabaseUser {
+function transformIntoDatabaseUser<TUserId>(raw: UserSchema<TUserId>): DatabaseUser<TUserId> {
 	const { id, ...attributes } = raw;
 	return {
 		id,

--- a/packages/adapter-mysql/src/drivers/mysql2.ts
+++ b/packages/adapter-mysql/src/drivers/mysql2.ts
@@ -3,7 +3,7 @@ import { MySQLAdapter } from "../base.js";
 import type { Controller, TableNames } from "../base.js";
 import type { Pool, Connection } from "mysql2/promise";
 
-export class Mysql2Adapter extends MySQLAdapter {
+export class Mysql2Adapter<TUserId> extends MySQLAdapter<TUserId> {
 	constructor(connection: Pool | Connection, tableNames: TableNames) {
 		super(new Mysql2Controller(connection), tableNames);
 	}

--- a/packages/adapter-mysql/src/drivers/planetscale.ts
+++ b/packages/adapter-mysql/src/drivers/planetscale.ts
@@ -3,7 +3,7 @@ import { MySQLAdapter } from "../base.js";
 import type { Controller, TableNames } from "../base.js";
 import type { Connection } from "@planetscale/database";
 
-export class PlanetScaleAdapter extends MySQLAdapter {
+export class PlanetScaleAdapter<TUserId> extends MySQLAdapter<TUserId> {
 	constructor(connection: Connection, tableNames: TableNames) {
 		super(new PlanetScaleController(connection), tableNames);
 	}

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -6,7 +6,10 @@ import type {
 	RegisteredDatabaseUserAttributes
 } from "lucia";
 
-export class PrismaAdapter<_PrismaClient extends PrismaClient> implements Adapter {
+/**
+ * IDK how should i play with prisma now, so i just leave it here
+ */
+export class PrismaAdapter<_PrismaClient extends PrismaClient> implements Adapter<string> {
 	private sessionModel: PrismaModel<SessionSchema>;
 	private userModel: PrismaModel<UserSchema>;
 
@@ -37,7 +40,7 @@ export class PrismaAdapter<_PrismaClient extends PrismaClient> implements Adapte
 
 	public async getSessionAndUser(
 		sessionId: string
-	): Promise<[session: DatabaseSession | null, user: DatabaseUser | null]> {
+	): Promise<[session: DatabaseSession<string> | null, user: DatabaseUser<string> | null]> {
 		const userModelKey = this.userModel.name[0].toLowerCase() + this.userModel.name.slice(1);
 		const result = await this.sessionModel.findUnique<{
 			// this is a lie to make TS shut up
@@ -56,7 +59,7 @@ export class PrismaAdapter<_PrismaClient extends PrismaClient> implements Adapte
 		return [transformIntoDatabaseSession(result), transformIntoDatabaseUser(userResult)];
 	}
 
-	public async getUserSessions(userId: string): Promise<DatabaseSession[]> {
+	public async getUserSessions(userId: string): Promise<DatabaseSession<string>[]> {
 		const result = await this.sessionModel.findMany({
 			where: {
 				userId
@@ -65,7 +68,7 @@ export class PrismaAdapter<_PrismaClient extends PrismaClient> implements Adapte
 		return result.map(transformIntoDatabaseSession);
 	}
 
-	public async setSession(value: DatabaseSession): Promise<void> {
+	public async setSession(value: DatabaseSession<string>): Promise<void> {
 		await this.sessionModel.create({
 			data: {
 				id: value.id,
@@ -98,7 +101,7 @@ export class PrismaAdapter<_PrismaClient extends PrismaClient> implements Adapte
 	}
 }
 
-function transformIntoDatabaseSession(raw: SessionSchema): DatabaseSession {
+function transformIntoDatabaseSession(raw: SessionSchema): DatabaseSession<string> {
 	const { id, userId, expiresAt, ...attributes } = raw;
 	return {
 		id,
@@ -108,7 +111,7 @@ function transformIntoDatabaseSession(raw: SessionSchema): DatabaseSession {
 	};
 }
 
-function transformIntoDatabaseUser(raw: UserSchema): DatabaseUser {
+function transformIntoDatabaseUser(raw: UserSchema): DatabaseUser<string> {
 	const { id, ...attributes } = raw;
 	return {
 		id,

--- a/packages/lucia/src/database.ts
+++ b/packages/lucia/src/database.ts
@@ -3,25 +3,25 @@ import type {
 	RegisteredDatabaseUserAttributes
 } from "./index.js";
 
-export interface Adapter {
+export interface Adapter<TUserId> {
 	getSessionAndUser(
 		sessionId: string
-	): Promise<[session: DatabaseSession | null, user: DatabaseUser | null]>;
-	getUserSessions(userId: string): Promise<DatabaseSession[]>;
-	setSession(session: DatabaseSession): Promise<void>;
+	): Promise<[session: DatabaseSession<TUserId> | null, user: DatabaseUser<TUserId> | null]>;
+	getUserSessions(userId: TUserId): Promise<DatabaseSession<TUserId>[]>;
+	setSession(session: DatabaseSession<TUserId>): Promise<void>;
 	updateSessionExpiration(sessionId: string, expiresAt: Date): Promise<void>;
 	deleteSession(sessionId: string): Promise<void>;
-	deleteUserSessions(userId: string): Promise<void>;
+	deleteUserSessions(userId: TUserId): Promise<void>;
 	deleteExpiredSessions(): Promise<void>;
 }
 
-export interface DatabaseUser {
-	id: string;
+export interface DatabaseUser<TUserId> {
+	id: TUserId;
 	attributes: RegisteredDatabaseUserAttributes;
 }
 
-export interface DatabaseSession {
-	userId: string;
+export interface DatabaseSession<TUserId> {
+	userId: TUserId;
 	expiresAt: Date;
 	id: string;
 	attributes: RegisteredDatabaseSessionAttributes;

--- a/packages/lucia/src/index.ts
+++ b/packages/lucia/src/index.ts
@@ -21,7 +21,7 @@ export interface Register {}
 export type RegisteredLucia = Register extends {
 	Lucia: infer _Lucia;
 }
-	? _Lucia extends Lucia<any, any>
+	? _Lucia extends Lucia<any, any, any>
 		? _Lucia
 		: Lucia
 	: Lucia;


### PR DESCRIPTION
### Problems
Currently, lucia only supports the string type userId, it makes difficult to apply that use existing integer userId or other types.
This was changed to enable user input through Generic. (Just play with TS)

### Features
 - When using schema as a constructor (ex: drizzle), the corresponding type is automatically used as the type of userId.
![image](https://github.com/lucia-auth/lucia/assets/43934024/7fe0ae79-17a0-43d4-8bb9-8e1d8f3a3690)

 - Mongodb's id type should be always string (afaik)

 - In other cases, use it as the Generic argument of Adapter.
```ts
const adapter = new Mysql2Adapter<number>(...);
```
### WIP
 - [ ] prisma
 
 Please let me know if you have any discuss or problems with the direction of the work.