### PR TITLE
CI: Release

### DIFF
--- a/.auri/$ygs60su4.md
+++ b/.auri/$ygs60su4.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth"
-type: "patch"
----
-
-Fixed the endpoint used for exchanging authorization codes for the Atlassian provider

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 3.5.3
+
+### Patch changes
+
+- [#1353](https://github.com/lucia-auth/lucia/pull/1353) by [@xyassini](https://github.com/xyassini) : Fixed the endpoint used for exchanging authorization codes for the Atlassian provider
+
 ## 3.5.2
 
 ### Patch changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@3.5.3
#### Patch changes

- [#1353](https://github.com/lucia-auth/lucia/pull/1353) by [@xyassini](https://github.com/xyassini) : Fixed the endpoint used for exchanging authorization codes for the Atlassian provider