### PR TITLE
Fix `LegacyScrypt`

### DIFF
--- a/.auri/$e3mj84c4.md
+++ b/.auri/$e3mj84c4.md
@@ -1,0 +1,6 @@
+---
+package: "lucia" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Fix `LegacyScrypt` generating malformed hash (see PR for fix)

--- a/packages/lucia/src/crypto.test.ts
+++ b/packages/lucia/src/crypto.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { Scrypt } from "./crypto.js";
+import { Scrypt, LegacyScrypt } from "./crypto.js";
 import { encodeHex } from "oslo/encoding";
 
 test("validateScryptHash() validates hashes generated with generateScryptHash()", async () => {
@@ -10,3 +10,12 @@ test("validateScryptHash() validates hashes generated with generateScryptHash()"
 	const falsePassword = encodeHex(crypto.getRandomValues(new Uint8Array(32)));
 	await expect(scrypt.verify(hash, falsePassword)).resolves.toBe(false);
 });
+
+test("LegacyScrypt", async () => {
+	const password = encodeHex(crypto.getRandomValues(new Uint8Array(32)));
+	const scrypt = new LegacyScrypt();
+	const hash = await scrypt.hash(password);
+	await expect(scrypt.verify(hash, password)).resolves.toBe(true);
+	const falsePassword = encodeHex(crypto.getRandomValues(new Uint8Array(32)));
+	await expect(scrypt.verify(hash, falsePassword)).resolves.toBe(false);
+})

--- a/packages/lucia/src/crypto.ts
+++ b/packages/lucia/src/crypto.ts
@@ -42,7 +42,7 @@ export class LegacyScrypt implements PasswordHashingAlgorithm {
 	async hash(password: string): Promise<string> {
 		const salt = encodeHex(crypto.getRandomValues(new Uint8Array(16)));
 		const key = await generateScryptKey(password.normalize("NFKC"), salt);
-		return `${salt}:${encodeHex(key)}`;
+		return `s2:${salt}:${encodeHex(key)}`;
 	}
 	async verify(hash: string, password: string): Promise<boolean> {
 		const parts = hash.split(":");


### PR DESCRIPTION
Fixes #1369 .

Hashes were supposed to include an `s2:` prefix but didn't. If you are using v3 in production, please add a `s2:` prefix to all hashes generated post v2. (e.g. `s2:aaaaaa:bbbbbbbbbb`)

Adds test to prevent the same issue from appearing