### PR TITLE
Fix DatabaseUserAttributes defined outside the Register interface in the doc

### DIFF
--- a/docs/pages/guides/email-and-password/2fa.md
+++ b/docs/pages/guides/email-and-password/2fa.md
@@ -32,9 +32,9 @@ export const lucia = new Lucia(adapter, {
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;
-	}
-	interface DatabaseUserAttributes {
-		two_factor_secret: string | null;
+		DatabaseUserAttributes: {
+			two_factor_secret: string | null;
+		};
 	}
 }
 ```

--- a/docs/pages/guides/email-and-password/basics.md
+++ b/docs/pages/guides/email-and-password/basics.md
@@ -38,9 +38,9 @@ export const lucia = new Lucia(adapter, {
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;
-	}
-	interface DatabaseUserAttributes {
-		email: string;
+		DatabaseUserAttributes: {
+			email: string;
+		};
 	}
 }
 ```

--- a/docs/pages/guides/email-and-password/email-verification-codes.md
+++ b/docs/pages/guides/email-and-password/email-verification-codes.md
@@ -30,10 +30,10 @@ export const lucia = new Lucia(adapter, {
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;
-	}
-	interface DatabaseUserAttributes {
-		email: string;
-		email_verified: boolean;
+		DatabaseUserAttributes: {
+			email: string;
+			email_verified: boolean;
+		};
 	}
 }
 ```

--- a/docs/pages/guides/email-and-password/email-verification-links.md
+++ b/docs/pages/guides/email-and-password/email-verification-links.md
@@ -32,10 +32,10 @@ export const lucia = new Lucia(adapter, {
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;
-	}
-	interface DatabaseUserAttributes {
-		email: string;
-		email_verified: boolean;
+		DatabaseUserAttributes: {
+			email: string;
+			email_verified: boolean;
+		};
 	}
 }
 ```

--- a/docs/pages/guides/oauth/basics.md
+++ b/docs/pages/guides/oauth/basics.md
@@ -46,10 +46,10 @@ export const lucia = new Lucia(adapter, {
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;
-	}
-	interface DatabaseUserAttributes {
-		github_id: number;
-		username: string;
+		DatabaseUserAttributes: {
+			github_id: number;
+			username: string;
+		};
 	}
 }
 ```


### PR DESCRIPTION
Some DatabaseUserAttributes are defined outside the `Register` interface in the doc.