### PR TITLE
Fix drizzle adapter setSession to work with cloudflare workers

### DIFF
--- a/packages/adapter-drizzle/src/drivers/mysql.ts
+++ b/packages/adapter-drizzle/src/drivers/mysql.ts
@@ -54,7 +54,7 @@ export class DrizzleMySQLAdapter implements Adapter {
 			userId: session.userId,
 			expiresAt: session.expiresAt,
 			...session.attributes
-		});
+		}).execute();
 	}
 
 	public async updateSessionExpiration(sessionId: string, expiresAt: Date): Promise<void> {


### PR DESCRIPTION
If we do not call execute explicitly in drizzle adapter it causes issues when deploying to cloudflare workers.
Refer to: [https://github.com/cloudflare/next-on-pages/issues/499](https://github.com/cloudflare/next-on-pages/issues/499)