### PR TITLE
Update mongoose.md with fixed typo

### DIFF
--- a/docs/pages/database/mongoose.md
+++ b/docs/pages/database/mongoose.md
@@ -16,7 +16,7 @@ You must handle the database connection manually.
 
 ```ts
 import { Lucia } from "lucia";
-import { MongoDBAdapter } from "@lucia-auth/adapter-mongodb";
+import { MongodbAdapter } from "@lucia-auth/adapter-mongodb";
 import mongoose from "mongoose";
 
 await mongoose.connect();


### PR DESCRIPTION
The provided example had a typo and was attempting to import an inexistent artefact.