### PR TITLE
typo: should be githubUser.login and not github.login

### DIFF
--- a/docs/pages/guides/oauth/multiple-providers.md
+++ b/docs/pages/guides/oauth/multiple-providers.md
@@ -56,7 +56,7 @@ await db.table("user").insert({
 	username: githubUser.login
 });
 await db.table("oauth_account").insert({
-	provider_id "github",
+	provider_id: "github",
 	provider_user_id: githubUser.id,
 	user_id: userId
 });

--- a/docs/pages/guides/oauth/multiple-providers.md
+++ b/docs/pages/guides/oauth/multiple-providers.md
@@ -53,7 +53,7 @@ const userId = generateId(15);
 await db.beginTransaction();
 await db.table("user").insert({
 	id: userId,
-	username: github.login
+	username: githubUser.login
 });
 await db.table("oauth_account").insert({
 	provider_id "github",


### PR DESCRIPTION
There is a small type in the multiple oauth providers guide.

When inserting into the user table, it should be githubUser.login and not github.login.