### PR TITLE
fix(adapter-drizzle): get session and user in one query

### DIFF
--- a/packages/adapter-drizzle/src/drivers/mysql.ts
+++ b/packages/adapter-drizzle/src/drivers/mysql.ts
@@ -31,11 +31,19 @@ export class DrizzleMySQLAdapter implements Adapter {
 	public async getSessionAndUser(
 		sessionId: string
 	): Promise<[session: DatabaseSession | null, user: DatabaseUser | null]> {
-		const [databaseSession, databaseUser] = await Promise.all([
-			this.getSession(sessionId),
-			this.getUserFromSessionId(sessionId)
-		]);
-		return [databaseSession, databaseUser];
+		const result = await this.db
+			.select({
+				user: this.userTable,
+				session: this.sessionTable
+			})
+			.from(this.sessionTable)
+			.innerJoin(this.userTable, eq(this.sessionTable.userId, this.userTable.id))
+			.where(eq(this.sessionTable.id, sessionId));
+		if (result.length !== 1) return [null, null];
+		return [
+			transformIntoDatabaseSession(result[0].session),
+			transformIntoDatabaseUser(result[0].user)
+		];
 	}
 
 	public async getUserSessions(userId: string): Promise<DatabaseSession[]> {
@@ -68,26 +76,6 @@ export class DrizzleMySQLAdapter implements Adapter {
 
 	public async deleteExpiredSessions(): Promise<void> {
 		await this.db.delete(this.sessionTable).where(lte(this.sessionTable.expiresAt, new Date()));
-	}
-
-	private async getSession(sessionId: string): Promise<DatabaseSession | null> {
-		const result = await this.db
-			.select()
-			.from(this.sessionTable)
-			.where(eq(this.sessionTable.id, sessionId));
-		if (result.length !== 1) return null;
-		return transformIntoDatabaseSession(result[0]);
-	}
-
-	private async getUserFromSessionId(sessionId: string): Promise<DatabaseUser | null> {
-		const { _, $inferInsert, $inferSelect, getSQL, ...userColumns } = this.userTable;
-		const result = await this.db
-			.select(userColumns)
-			.from(this.sessionTable)
-			.innerJoin(this.userTable, eq(this.sessionTable.userId, this.userTable.id))
-			.where(eq(this.sessionTable.id, sessionId));
-		if (result.length !== 1) return null;
-		return transformIntoDatabaseUser(result[0]);
 	}
 }
 


### PR DESCRIPTION
DrizzleORM has [Partial Select API](https://orm.drizzle.team/docs/joins#partial-select) so it's very easy to get session and user in one database query.

<details>
<summary>Simple example how it works</summary>

```ts
import { eq, sql } from 'drizzle-orm';
import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
import { drizzle } from 'drizzle-orm/better-sqlite3';
import sqlite from 'better-sqlite3';

const userTable = sqliteTable('user', {
  id: text('id').notNull().primaryKey(),
  username: text('username').notNull(),
});

const sessionTable = sqliteTable('session', {
  id: text('id').notNull().primaryKey(),
  userId: text('user_id')
    .notNull()
    .references(() => userTable.id),
  expiresAt: integer('expires_at').notNull(),
});

const sqliteDb = sqlite(':memory:');
const db = drizzle(sqliteDb, { schema: { userTable, sessionTable } });

db.run(sql`CREATE TABLE user (
  id TEXT NOT NULL PRIMARY KEY,
  username TEXT NOT NULL
)`);
db.run(sql`CREATE TABLE session (
  id TEXT NOT NULL PRIMARY KEY,
  expires_at INTEGER NOT NULL,
  user_id TEXT NOT NULL,
  FOREIGN KEY (user_id) REFERENCES user(id)
)`);
await db.insert(userTable).values({ id: '1', username: 'John' });
await db.insert(sessionTable).values({ id: '1', userId: '1', expiresAt: 0 });

const result = await db
  .select({
    user: userTable,
    session: sessionTable,
  })
  .from(sessionTable)
  .innerJoin(userTable, eq(sessionTable.userId, userTable.id))
  .where(eq(sessionTable.id, '1'));

console.log(result);
/*
[
  {
    user: { id: '1', username: 'John' },
    session: { id: '1', userId: '1', expiresAt: 0 }
  }
]
*/
```
</details>