### PR TITLE
Fix wrong import for MongodbAdapter in mongodb database doc

### DIFF
--- a/docs/pages/database/mongodb.md
+++ b/docs/pages/database/mongodb.md
@@ -16,7 +16,7 @@ You must handle the database connection manually.
 
 ```ts
 import { Lucia } from "lucia";
-import { MongoDBAdapter } from "@lucia-auth/adapter-mongodb";
+import { MongodbAdapter } from "@lucia-auth/adapter-mongodb";
 import { Collection, MongoClient } from "mongodb";
 
 const client = new MongoClient();


### PR DESCRIPTION
On the mongodb database doc there's a spelling/case mistake.

Under Usage the MongodbAdapter was using the wrong import.