### PR TITLE
Fix DrizzleSQLiteAdapter constructor signature

### DIFF
--- a/packages/adapter-drizzle/src/drivers/mysql.ts
+++ b/packages/adapter-drizzle/src/drivers/mysql.ts
@@ -5,13 +5,13 @@ import type { MySqlColumn, MySqlDatabase, MySqlTableWithColumns } from "drizzle-
 import type { InferSelectModel } from "drizzle-orm";
 
 export class DrizzleMySQLAdapter implements Adapter {
-	private db: MySqlDatabase<any, any>;
+	private db: MySqlDatabase<any, any, any>;
 
 	private sessionTable: MySQLSessionTable;
 	private userTable: MySQLUserTable;
 
 	constructor(
-		db: MySqlDatabase<any, any>,
+		db: MySqlDatabase<any, any, any>,
 		sessionTable: MySQLSessionTable,
 		userTable: MySQLUserTable
 	) {

--- a/packages/adapter-drizzle/src/drivers/postgresql.ts
+++ b/packages/adapter-drizzle/src/drivers/postgresql.ts
@@ -5,13 +5,13 @@ import type { PgColumn, PgDatabase, PgTableWithColumns } from "drizzle-orm/pg-co
 import type { InferSelectModel } from "drizzle-orm";
 
 export class DrizzlePostgreSQLAdapter implements Adapter {
-	private db: PgDatabase<any, any>;
+	private db: PgDatabase<any, any, any>;
 
 	private sessionTable: PostgreSQLSessionTable;
 	private userTable: PostgreSQLUserTable;
 
 	constructor(
-		db: PgDatabase<any, any>,
+		db: PgDatabase<any, any, any>,
 		sessionTable: PostgreSQLSessionTable,
 		userTable: PostgreSQLUserTable
 	) {

--- a/packages/adapter-drizzle/src/drivers/sqlite.ts
+++ b/packages/adapter-drizzle/src/drivers/sqlite.ts
@@ -15,7 +15,7 @@ export class DrizzleSQLiteAdapter implements Adapter {
 	private userTable: SQLiteUserTable;
 
 	constructor(
-		db: BaseSQLiteDatabase<any, any>,
+		db: BaseSQLiteDatabase<any, any, any>,
 		sessionTable: SQLiteSessionTable,
 		userTable: SQLiteUserTable
 	) {


### PR DESCRIPTION
In the signature of the DrizzleSQLiteAdapter constructor, the generic type TFullSchema of BaseSQLiteDatabase was not set. Consequently, an instance with a schema couldn't be passed.

<details>

<summary>example</summary>

```ts
import { DrizzleSQLiteAdapter } from "@lucia-auth/adapter-drizzle";
import { Database } from "bun:sqlite";
import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
import { drizzle } from "drizzle-orm/bun-sqlite";

const sqliteDB = new Database(":memory:");

const userTable = sqliteTable("user", {
  id: text("id").notNull().primaryKey(),
});

const sessionTable = sqliteTable("user_session", {
  id: text("id").notNull().primaryKey(),
  userId: text("user_id")
    .notNull()
    .references(() => userTable.id),
  expiresAt: integer("expires_at").notNull(),
});

const db = drizzle(sqliteDB);
new DrizzleSQLiteAdapter(db, sessionTable, userTable); // <- OK

const dbWithSchema = drizzle(sqliteDB, { schema: { userTable, sessionTable } });
new DrizzleSQLiteAdapter(dbWithSchema, sessionTable, userTable); // <- Error
```

</details>