### PR TITLE
Update index.md - Added specific configuration example for Svelte/Kit

### DIFF
--- a/docs/pages/getting-started/sveltekit.md
+++ b/docs/pages/getting-started/sveltekit.md
@@ -20,7 +20,6 @@ If you use `@sveltejs/adapter-node`, make sure to install `oslo` as a `dependenc
 npm install oslo
 ```
 
-[^1]: See [SvelteKit documentation](https://kit.svelte.dev/docs/adapter-node#deploying) for details.
 
 ## Initialize Lucia
 

--- a/docs/pages/getting-started/sveltekit.md
+++ b/docs/pages/getting-started/sveltekit.md
@@ -14,7 +14,7 @@ npm install -D lucia
 
 While not strictly necessary, we recommend installing [Oslo](https://oslo.js.org), which Lucia is built on, for various auth utilities (which a lot of the guides use).
 
-If you use `@sveltejs/adapter-node`, make sure to install `oslo` as a `dependency`, not as `devDependency` to prevent Rollup from bundling `oslo`.[^1]
+If you use `@sveltejs/adapter-node`, make sure to install `oslo` as a `dependency`, not as `devDependency` to prevent Rollup from bundling `oslo`. See the [SvelteKit documentation](https://kit.svelte.dev/docs/adapter-node#deploying) for details.
 
 ```
 npm install oslo

--- a/docs/pages/getting-started/sveltekit.md
+++ b/docs/pages/getting-started/sveltekit.md
@@ -6,11 +6,21 @@ title: "Getting started in Sveltekit"
 
 ## Installation
 
-Install Lucia using your package manager of your choice. While not strictly necessary, we recommend installing [Oslo](https://oslo.js.org), which Lucia is built on, for various auth utilities (which a lot of the guides use).
+Install Lucia using your package manager of your choice.
 
 ```
-npm install lucia oslo
+npm install -D lucia
 ```
+
+While not strictly necessary, we recommend installing [Oslo](https://oslo.js.org), which Lucia is built on, for various auth utilities (which a lot of the guides use).
+
+If you use `@sveltejs/adapter-node`, make sure to install `oslo` as a `dependency`, not as `devDependency` to prevent Rollup from bundling `oslo`.[^1]
+
+```
+npm install oslo
+```
+
+[^1]: See [SvelteKit documentation](https://kit.svelte.dev/docs/adapter-node#deploying) for details.
 
 ## Initialize Lucia
 

--- a/docs/pages/upgrade-v3/index.md
+++ b/docs/pages/upgrade-v3/index.md
@@ -212,7 +212,7 @@ const nextConfig = {
 
 ### SvelteKit
 
-???
+(Is this neccessary? For Svelte only maybe? Or other sveltekit adapters?)
 
 ```ts
 // vite.config.ts

--- a/docs/pages/upgrade-v3/index.md
+++ b/docs/pages/upgrade-v3/index.md
@@ -209,3 +209,21 @@ const nextConfig = {
 	}
 };
 ```
+
+### SvelteKit
+
+???
+
+```ts
+// vite.config.ts
+export default defineConfig({
+	// ...
+	optimizeDeps: {
+		exclude: ["oslo"]
+	}
+});
+```
+
+#### @sveltejs/adapter-node
+
+Install `oslo` as a `dependency`, not as `devDependency` to prevent `@sveltejs/adapter-node` to bundle `oslo`.

--- a/docs/pages/upgrade-v3/index.md
+++ b/docs/pages/upgrade-v3/index.md
@@ -212,18 +212,12 @@ const nextConfig = {
 
 ### SvelteKit
 
-(Is this neccessary? For Svelte only maybe? Or other sveltekit adapters?)
-
-```ts
-// vite.config.ts
-export default defineConfig({
-	// ...
-	optimizeDeps: {
-		exclude: ["oslo"]
-	}
-});
-```
-
 #### @sveltejs/adapter-node
 
-Install `oslo` as a `dependency`, not as `devDependency` to prevent `@sveltejs/adapter-node` to bundle `oslo`.
+Make sure to install `oslo` as a `dependency`, not as `devDependency` to prevent `@sveltejs/adapter-node` from bundling `oslo`.
+
+As per SvelteKit documentation :
+
+>Development dependencies will be bundled into your app using Rollup. To control whether a given package is bundled or externalised, place it in devDependencies or dependencies respectively in your package.json.
+
+See [SvelteKit documentation](https://kit.svelte.dev/docs/adapter-node#deploying) for details.


### PR DESCRIPTION
Added specific configuration example for Svelte/Kit

I am not sure exactly what to include, since I tested only for `sveltekit` with `adapter-node` specifically.

I couldn't `build` successfully until I moved `oslo` from `devDependencies` to `dependencies`. I tried with `optimizeDeps: { exclude: ["oslo"] }` before, but it did not solve my issue. The `vite build` process could succeed, but then the `@sveltejs/adapter-node` step would fail.

Here's the stack in case someone have the same problem :

```
> Using @sveltejs/adapter-node
error during build:
RollupError: Unexpected character '\u{7f}'
    at error (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/parseAst.js:337:30)
    at parseError (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/parseAst.js:972:9)
    at convertNode (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/parseAst.js:2061:12)
    at convertProgram (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/parseAst.js:965:12)
    at parseAstAsync (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/parseAst.js:2112:12)
    at async Module.tryParseAsync (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/node-entry.js:13571:20)
    at async Module.setSource (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/node-entry.js:13152:35)
    at async ModuleLoader.addModuleSource (file:///home/$USER/sveltekit-demo/node_modules/.pnpm/rollup@4.10.0/node_modules/rollup/dist/es/shared/node-entry.js:17847:13)
 ELIFECYCLE  Command failed with exit code 1.
```