### PR TITLE
[DOCS] Update Github OAuth guide to contain 'User-Agent' in fetch header

### DIFF
--- a/docs/pages/guides/oauth/account-linking.md
+++ b/docs/pages/guides/oauth/account-linking.md
@@ -18,7 +18,6 @@ const userResponse = await fetch("https://api.github.com/user", {
 	headers: {
 		Authorization: `Bearer ${tokens.accessToken}`
 		'User-Agent': 'Application-Name',
-		
 	}
 });
 const githubUser = await userResponse.json();

--- a/docs/pages/guides/oauth/account-linking.md
+++ b/docs/pages/guides/oauth/account-linking.md
@@ -17,6 +17,8 @@ const tokens = await github.validateAuthorizationCode(code);
 const userResponse = await fetch("https://api.github.com/user", {
 	headers: {
 		Authorization: `Bearer ${tokens.accessToken}`
+		'User-Agent': 'Application-Name',
+		
 	}
 });
 const githubUser = await userResponse.json();

--- a/docs/pages/guides/oauth/account-linking.md
+++ b/docs/pages/guides/oauth/account-linking.md
@@ -17,7 +17,7 @@ const tokens = await github.validateAuthorizationCode(code);
 const userResponse = await fetch("https://api.github.com/user", {
 	headers: {
 		Authorization: `Bearer ${tokens.accessToken}`
-		'User-Agent': 'Application-Name',
+		'User-Agent': 'Application-Name', // input your github application name
 	}
 });
 const githubUser = await userResponse.json();

--- a/docs/pages/guides/oauth/account-linking.md
+++ b/docs/pages/guides/oauth/account-linking.md
@@ -17,7 +17,7 @@ const tokens = await github.validateAuthorizationCode(code);
 const userResponse = await fetch("https://api.github.com/user", {
 	headers: {
 		Authorization: `Bearer ${tokens.accessToken}`
-		'User-Agent': 'Application-Name', // input your github application name
+		"User-Agent": "my-app", // GitHub requires a User-Agent header
 	}
 });
 const githubUser = await userResponse.json();


### PR DESCRIPTION
As per the GitHub [documentation](https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api?apiVersion=2022-11-28#user-agent-required):

_"Requests without a valid User-Agent header will be rejected. You should use your username or the name of your application for the User-Agent value"_

I was following the account-linking example in the documentation and kept getting statuscode 403 without the `User-Agent` header.



