### PR TITLE
Resolve (docs) "Fixed Broken 404 Page Lucia Auth Tutorials for Next.js"

### DIFF
--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -11,15 +11,17 @@ Explore our tutorials for implementing Lucia Auth with GitHub OAuth or tradition
 Learn to set up GitHub OAuth, handle authentication, and manage user sessions.
 
 -   [Astro](/tutorials/github-oauth/astro)
--   [SvelteKit](/tutorials/github-oauth/sveltekit)
+-   [Next.js App router](/tutorials/username-and-password/nextjs-app)
+-   [Next.js Pages router](/tutorials/username-and-password/nextjs-pages)
 -   [Nuxt](/tutorials/github-oauth/nuxt)
--   [Next.js](/tutorials/github-oauth/nextjs)
+-   [SvelteKit](/tutorials/github-oauth/sveltekit)
 
 ## Username and Password
 
 Understand how to implement a secure username and password authentication system.
 
 -   [Astro](/tutorials/username-and-password/astro)
--   [SvelteKit](/tutorials/username-and-password/sveltekit)
+-   [Next.js App router](/tutorials/username-and-password/nextjs-app)
+-   [Next.js Pages router](/tutorials/username-and-password/nextjs-pages)
 -   [Nuxt](/tutorials/username-and-password/nuxt)
--   [Next.js](/tutorials/username-and-password/nextjs)
+-   [SvelteKit](/tutorials/username-and-password/sveltekit)

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -11,8 +11,8 @@ Explore our tutorials for implementing Lucia Auth with GitHub OAuth or tradition
 Learn to set up GitHub OAuth, handle authentication, and manage user sessions.
 
 -   [Astro](/tutorials/github-oauth/astro)
--   [Next.js App router](/tutorials/username-and-password/nextjs-app)
--   [Next.js Pages router](/tutorials/username-and-password/nextjs-pages)
+-   [Next.js App router](/tutorials/github-oauth/nextjs-app)
+-   [Next.js Pages router](/tutorials/github-oauth/nextjs-pages)
 -   [Nuxt](/tutorials/github-oauth/nuxt)
 -   [SvelteKit](/tutorials/github-oauth/sveltekit)
 


### PR DESCRIPTION
Hi @pilcrowOnPaper,

Please kindly check it out later. \
Thank you! 

Note:
- Fixed link not properly added to the Tutorials page (should be **Next.js Pages/App router** instead of **Next.js**).
- Additionally, also reordering the list to matched like the others.


Attachments:

- Wrong link and list for Next.js.
  ![image](https://github.com/lucia-auth/lucia/assets/25473432/a9cfdedc-71f5-401d-a06c-bfb2177e4652)

- Matched the order list.
  ![image](https://github.com/lucia-auth/lucia/assets/25473432/a42a2000-4147-4bd4-9684-7f0fea42d5e6)

