### PR TITLE
[DOCS]: Include ActionResult interface in nextjs github-oath tutorial

### DIFF
--- a/docs/pages/tutorials/github-oauth/nextjs-app.md
+++ b/docs/pages/tutorials/github-oauth/nextjs-app.md
@@ -292,6 +292,6 @@ async function logout(): Promise<ActionResult> {
 }
 
 interface ActionResult {
-  error: string | null;
+	error: string | null;
 }
 ```

--- a/docs/pages/tutorials/github-oauth/nextjs-app.md
+++ b/docs/pages/tutorials/github-oauth/nextjs-app.md
@@ -290,4 +290,8 @@ async function logout(): Promise<ActionResult> {
 	cookies().set(sessionCookie.name, sessionCookie.value, sessionCookie.attributes);
 	return redirect("/login");
 }
+
+interface ActionResult {
+  error: string | null;
+}
 ```

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.0
 
-- Add Neon HTTP adapter ([#1413](https://github.com/lucia-auth/lucia/pull/1413))
+-   Add Neon HTTP adapter ([#1413](https://github.com/lucia-auth/lucia/pull/1413))
 
 ## 3.0.0
 


### PR DESCRIPTION
The ActionResult interface isn't included in the docs. It might be confusing given that it is used in the example project.
https://github.com/lucia-auth/examples/blob/main/nextjs-app/github-oauth/app/page.tsx