### PR TITLE
docs(custom-providers): correct method name

### DIFF
--- a/docs/pages/guides/oauth/custom-providers.md
+++ b/docs/pages/guides/oauth/custom-providers.md
@@ -76,7 +76,7 @@ await oauth2Client.validateAuthorizationCode<{
 
 ## Refresh access tokens
 
-Use [`OAuth2Client.validateAuthorizationCode()`](https://oslo.js.org/reference/oauth2/OAuth2Client/refreshAccessToken) to refresh an access token. The API is similar to `validateAuthorizationCode()` and it also throws an `OAuth2RequestError` on error responses.
+Use [`OAuth2Client.refreshAccessToken()`](https://oslo.js.org/reference/oauth2/OAuth2Client/refreshAccessToken) to refresh an access token. The API is similar to `validateAuthorizationCode()` and it also throws an `OAuth2RequestError` on error responses.
 
 ```ts
 try {


### PR DESCRIPTION
I think it is supposed to be `refreshAccessToken`.