### PR TITLE
Fix missing userId type in `@lucia-auth/adapter-drizzle`

### DIFF
--- a/packages/adapter-drizzle/src/drivers/mysql.ts
+++ b/packages/adapter-drizzle/src/drivers/mysql.ts
@@ -88,7 +88,7 @@ export type MySQLUserTable = MySqlTableWithColumns<{
 				tableName: any;
 				dataType: any;
 				columnType: any;
-				data: string;
+				data: UserId;
 				driverParam: any;
 				notNull: true;
 				hasDefault: boolean; // must be boolean instead of any to allow default values
@@ -140,7 +140,7 @@ export type MySQLSessionTable = MySqlTableWithColumns<{
 				enumValues: any;
 				tableName: any;
 				columnType: any;
-				data: string;
+				data: UserId;
 				driverParam: any;
 				hasDefault: false;
 				name: any;

--- a/packages/adapter-drizzle/src/drivers/postgresql.ts
+++ b/packages/adapter-drizzle/src/drivers/postgresql.ts
@@ -88,7 +88,7 @@ export type PostgreSQLUserTable = PgTableWithColumns<{
 				tableName: any;
 				dataType: any;
 				columnType: any;
-				data: string;
+				data: UserId;
 				driverParam: any;
 				notNull: true;
 				hasDefault: boolean; // must be boolean instead of any to allow default values
@@ -140,7 +140,7 @@ export type PostgreSQLSessionTable = PgTableWithColumns<{
 				enumValues: any;
 				tableName: any;
 				columnType: any;
-				data: string;
+				data: UserId;
 				driverParam: any;
 				hasDefault: false;
 				name: any;

--- a/packages/adapter-drizzle/src/drivers/sqlite.ts
+++ b/packages/adapter-drizzle/src/drivers/sqlite.ts
@@ -100,7 +100,7 @@ export type SQLiteUserTable = SQLiteTableWithColumns<{
 				tableName: any;
 				dataType: any;
 				columnType: any;
-				data: string;
+				data: UserId;
 				driverParam: any;
 				notNull: true;
 				hasDefault: boolean; // must be boolean instead of any to allow default values
@@ -152,7 +152,7 @@ export type SQLiteSessionTable = SQLiteTableWithColumns<{
 				enumValues: any;
 				tableName: any;
 				columnType: any;
-				data: string;
+				data: UserId;
 				driverParam: any;
 				hasDefault: false;
 				name: any;


### PR DESCRIPTION
Fix type error when user ID is numeric in Drizzle adapter

ref: #1472