### PR TITLE
Allow userId in session table in sqlite drizzle adapter to be number

### DIFF
--- a/packages/adapter-drizzle/src/drivers/sqlite.ts
+++ b/packages/adapter-drizzle/src/drivers/sqlite.ts
@@ -147,7 +147,7 @@ export type SQLiteSessionTable = SQLiteTableWithColumns<{
 		>;
 		userId: SQLiteColumn<
 			{
-				dataType: "string";
+				dataType: any;
 				notNull: true;
 				enumValues: any;
 				tableName: any;


### PR DESCRIPTION
This fix allows userId to be a number if `UserId` is registered as a number when using drizzle sqlite adapter.
In drizzle postgres and mysql adapters, the `dataType` is already `any` while `data` is `UserId`.