### PR TITLE
docs: update session cookie validation docs for hono

### DIFF
--- a/docs/pages/guides/validate-session-cookies/hono.md
+++ b/docs/pages/guides/validate-session-cookies/hono.md
@@ -23,7 +23,7 @@ const app = new Hono<{
 	};
 }>();
 
-app.use("*", (c, next) => {
+app.use("*", async (c, next) => {
 	// CSRF middleware
 	if (c.req.method === "GET") {
 		return next();
@@ -38,7 +38,7 @@ app.use("*", (c, next) => {
 });
 
 app.use("*", async (c, next) => {
-	const sessionId = getCookie(lucia.sessionCookieName) ?? null;
+	const sessionId = getCookie(c, lucia.sessionCookieName) ?? null;
 	if (!sessionId) {
 		c.set("user", null);
 		c.set("session", null);


### PR DESCRIPTION
There was a type error where middlewares needed to be async and `getCookie` expects `context` as first argument.