### PR TITLE
docs: update solidstart examples

### DIFF
--- a/docs/pages/getting-started/solidstart.md
+++ b/docs/pages/getting-started/solidstart.md
@@ -46,42 +46,48 @@ It's a bit verbose, but it just reads the session cookie, validates it, and sets
 
 ```ts
 // src/middleware.ts
-import { createMiddleware, appendHeader, getCookie, getHeader } from "@solidjs/start/server";
+import { createMiddleware } from "@solidjs/start/middleware";
+import { appendHeader, getCookie, getHeader } from "vinxi/http";
 import { Session, User, verifyRequestOrigin } from "lucia";
 import { lucia } from "./lib/auth";
 
 export default createMiddleware({
 	onRequest: async (event) => {
-		if (event.node.req.method !== "GET") {
-			const originHeader = getHeader(event, "Origin") ?? null;
-			const hostHeader = getHeader(event, "Host") ?? null;
+		const { nativeEvent } = event;
+		if (event.request.method !== "GET") {
+			const originHeader = getHeader(nativeEvent, "Origin") ?? null;
+			// NOTE: You may need to use `X-Forwarded-Host` instead
+			const hostHeader = getHeader(nativeEvent, "Host") ?? null;
 			if (!originHeader || !hostHeader || !verifyRequestOrigin(originHeader, [hostHeader])) {
-				event.node.res.writeHead(403).end();
+				nativeEvent.node.res.writeHead(403).end();
 				return;
 			}
 		}
-
-		const sessionId = getCookie(event, lucia.sessionCookieName) ?? null;
+		const sessionId = getCookie(nativeEvent, lucia.sessionCookieName) ?? null;
 		if (!sessionId) {
-			event.context.session = null;
-			event.context.user = null;
+			event.locals.session = null;
+			event.locals.user = null;
 			return;
 		}
 
 		const { session, user } = await lucia.validateSession(sessionId);
 		if (session && session.fresh) {
-			appendHeader(event, "Set-Cookie", lucia.createSessionCookie(session.id).serialize());
+			appendHeader(
+				nativeEvent,
+				"Set-Cookie",
+				lucia.createSessionCookie(session.id).serialize()
+			);
 		}
 		if (!session) {
-			appendHeader(event, "Set-Cookie", lucia.createBlankSessionCookie().serialize());
+			appendHeader(nativeEvent, "Set-Cookie", lucia.createBlankSessionCookie().serialize());
 		}
-		event.context.session = session;
-		event.context.user = user;
+		event.locals.session = session;
+		event.locals.user = user;
 	}
 });
 
-declare module "vinxi/server" {
-	interface H3EventContext {
+declare module "@solidjs/start/server" {
+	interface RequestEventLocals {
 		user: User | null;
 		session: Session | null;
 	}

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.2
 
-- Update peer dependencies.
+-   Update peer dependencies.
 
 ## 3.1.1
 


### PR DESCRIPTION
Noticed solidstart examples for sessions were outdated.

I decided to use event.locals instead of event.nativeEvent.context because it's what is mentioned in [solidstart docs](https://start.solidjs.com/api/RequestEvent#locals).