### PR TITLE
docs: fix typo

### DIFF
--- a/docs/pages/guides/email-and-password/2fa.md
+++ b/docs/pages/guides/email-and-password/2fa.md
@@ -47,7 +47,7 @@ When the user signs up, set `two_factor_secret` to `null` to indicate the user h
 app.post("/signup", async () => {
 	// ...
 
-	const userId = generateId();
+	const userId = generateId(15);
 
 	await db.table("user").insert({
 		id: userId,

--- a/docs/pages/guides/email-and-password/email-verification-codes.md
+++ b/docs/pages/guides/email-and-password/email-verification-codes.md
@@ -87,7 +87,7 @@ import { generateId } from "lucia";
 app.post("/signup", async () => {
 	// ...
 
-	const userId = generateId();
+	const userId = generateId(15);
 
 	await db.table("user").insert({
 		id: userId,

--- a/docs/pages/guides/email-and-password/email-verification-links.md
+++ b/docs/pages/guides/email-and-password/email-verification-links.md
@@ -86,7 +86,7 @@ import { generateId } from "lucia";
 app.post("/signup", async () => {
 	// ...
 
-	const userId = generateId();
+	const userId = generateId(15);
 
 	await db.table("user").insert({
 		id: userId,

--- a/docs/pages/guides/oauth/account-linking.md
+++ b/docs/pages/guides/oauth/account-linking.md
@@ -50,7 +50,7 @@ if (existingUser) {
 		user_id: existingUser.id
 	});
 } else {
-	const userId = generateId();
+	const userId = generateId(15);
 	await db.beginTransaction();
 	await db.table("user").insert({
 		id: userId,


### PR DESCRIPTION
The examples don't pass a param to `generateId()`, which leads to an empty returned string. 