### PR TITLE
docs: fix undefined sveltekit env vars

### DIFF
--- a/docs/pages/tutorials/github-oauth/sveltekit.md
+++ b/docs/pages/tutorials/github-oauth/sveltekit.md
@@ -80,10 +80,11 @@ Initialize the GitHub provider with the client ID and secret.
 // src/lib/server/auth.ts
 // ...
 import { GitHub } from "arctic";
+import { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } from '$env/static/private';
 
 export const github = new GitHub(
-	import.meta.env.GITHUB_CLIENT_ID,
-	import.meta.env.GITHUB_CLIENT_SECRET
+	GITHUB_CLIENT_ID,
+	GITHUB_CLIENT_SECRET
 );
 ```
 


### PR DESCRIPTION
Using `import.meta.env` returns `undefined`