### PR TITLE
feat(adapter-prisma): support fetching user relations

### DIFF
--- a/docs/pages/database/prisma.md
+++ b/docs/pages/database/prisma.md
@@ -49,6 +49,6 @@ To include relations in the user object, pass an object with the relations to in
 
 ```ts
 const adapter = new PrismaAdapter(client.session, client.user, {
-	user: true
+	settings: true
 });
 ```

--- a/docs/pages/database/prisma.md
+++ b/docs/pages/database/prisma.md
@@ -42,3 +42,13 @@ const client = new PrismaClient();
 
 const adapter = new PrismaAdapter(client.session, client.user);
 ```
+
+### Including Relations
+
+To include relations in the user object, pass an object with the relations to include.
+
+```ts
+const adapter = new PrismaAdapter(client.session, client.user, {
+	user: true
+});
+```

--- a/packages/adapter-prisma/prisma/migrations/20240421180100_init/migration.sql
+++ b/packages/adapter-prisma/prisma/migrations/20240421180100_init/migration.sql
@@ -1,0 +1,18 @@
+-- DropIndex
+DROP INDEX "Session_id_key";
+
+-- DropIndex
+DROP INDEX "User_id_key";
+
+-- CreateTable
+CREATE TABLE "Settings" (
+    "userId" TEXT NOT NULL PRIMARY KEY,
+    "theme" TEXT NOT NULL,
+    CONSTRAINT "Settings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Settings_userId_key" ON "Settings"("userId");
+
+-- CreateIndex
+CREATE INDEX "Settings_userId_idx" ON "Settings"("userId");

--- a/packages/adapter-prisma/prisma/schema.prisma
+++ b/packages/adapter-prisma/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   id           String    @id
   username     String    @unique
   auth_session Session[]
+  settings     Settings?
 }
 
 model Session {
@@ -22,6 +23,14 @@ model Session {
   expiresAt DateTime
   country   String
   user      User     @relation(references: [id], fields: [userId], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+model Settings {
+  userId String @id @unique
+  theme  String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
 }

--- a/packages/adapter-prisma/tests/prisma.ts
+++ b/packages/adapter-prisma/tests/prisma.ts
@@ -5,16 +5,32 @@ import { PrismaAdapter } from "../src/index.js";
 
 const client = new PrismaClient();
 
-const adapter = new PrismaAdapter(client.session, client.user);
+const adapter = new PrismaAdapter(client.session, client.user, {
+	settings: true
+});
 
 await client.user.create({
 	data: {
 		id: databaseUser.id,
-		...databaseUser.attributes
+		...databaseUser.attributes,
+		settings: {
+			create: {
+				theme: "test"
+			}
+		}
 	}
 });
 
-await testAdapter(adapter);
+await testAdapter(adapter, {
+	...databaseUser,
+	attributes: {
+		...databaseUser.attributes,
+		settings: {
+			userId: databaseUser.id,
+			theme: "test"
+		}
+	}
+});
 
 await client.session.deleteMany();
 await client.user.deleteMany();
@@ -25,6 +41,10 @@ declare module "lucia" {
 	interface Register {
 		DatabaseUserAttributes: {
 			username: string;
+			settings?: {
+				userId: string;
+				theme: string;
+			};
 		};
 	}
 }

--- a/packages/adapter-test/src/index.ts
+++ b/packages/adapter-test/src/index.ts
@@ -9,10 +9,10 @@ export const databaseUser: DatabaseUser = {
 	}
 };
 
-export async function testAdapter(adapter: Adapter) {
+export async function testAdapter(adapter: Adapter, _databaseUser: DatabaseUser = databaseUser) {
 	console.log(`\n\x1B[38;5;63;1m[start]  \x1B[0mRunning adapter tests\x1B[0m\n`);
 	const databaseSession: DatabaseSession = {
-		userId: databaseUser.id,
+		userId: _databaseUser.id,
 		id: generateRandomString(40, alphabet("0-9", "a-z")),
 		// get random date with 0ms
 		expiresAt: new Date(Math.floor(Date.now() / 1000) * 1000 + 10_000),
@@ -27,14 +27,14 @@ export async function testAdapter(adapter: Adapter) {
 	});
 
 	await test("getUserSessions() returns empty array on invalid user id", async () => {
-		const result = await adapter.getUserSessions(databaseUser.id);
+		const result = await adapter.getUserSessions(_databaseUser.id);
 		assert.deepStrictEqual(result, []);
 	});
 
 	await test("setSession() creates session and getSessionAndUser() returns created session and associated user", async () => {
 		await adapter.setSession(databaseSession);
 		const result = await adapter.getSessionAndUser(databaseSession.id);
-		assert.deepStrictEqual(result, [databaseSession, databaseUser]);
+		assert.deepStrictEqual(result, [databaseSession, _databaseUser]);
 	});
 
 	await test("deleteSession() deletes session", async () => {
@@ -48,12 +48,12 @@ export async function testAdapter(adapter: Adapter) {
 		databaseSession.expiresAt = new Date(databaseSession.expiresAt.getTime() + 10_000);
 		await adapter.updateSessionExpiration(databaseSession.id, databaseSession.expiresAt);
 		const result = await adapter.getSessionAndUser(databaseSession.id);
-		assert.deepStrictEqual(result, [databaseSession, databaseUser]);
+		assert.deepStrictEqual(result, [databaseSession, _databaseUser]);
 	});
 
 	await test("deleteExpiredSessions() deletes all expired sessions", async () => {
 		const expiredSession: DatabaseSession = {
-			userId: databaseUser.id,
+			userId: _databaseUser.id,
 			id: generateRandomString(40, alphabet("0-9", "a-z")),
 			expiresAt: new Date(Math.floor(Date.now() / 1000) * 1000 - 10_000),
 			attributes: {


### PR DESCRIPTION
This change would allow the user to include additional relations in the `user` object when querying.

The type for the includable relations is a bit suboptimal, as intellisense will show some keys that cannot be included, but only with type of `undefined`. See below:

<img width="518" alt="image" src="https://github.com/lucia-auth/lucia/assets/7687617/f2f04b19-09b3-4d92-814e-433f2a44e81a">

<img width="517" alt="image" src="https://github.com/lucia-auth/lucia/assets/7687617/067baab0-a6e7-447c-a6f5-6f71e58eda54">


This can probably be fixed, but I first wanted to look for some feedback, e.g. if a change like this would be considered in general, before spending more time on it.