### PR TITLE
chore(adapter-drizzle): mark drizzle-orm as a peer dependency

### DIFF
--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -37,7 +37,7 @@
 	},
 	"peerDependencies": {
 		"lucia": "3.x",
-		"drizzle-orm": "^0"
+		"drizzle-orm": ">= 0.29 <1"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -36,14 +36,15 @@
 		".": "./dist/index.js"
 	},
 	"peerDependencies": {
-		"lucia": "3.x"
+		"lucia": "3.x",
+		"drizzle-orm": "^0"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",
 		"@types/better-sqlite3": "^7.6.3",
 		"better-sqlite3": "^8.4.0",
 		"dotenv": "^16.0.3",
-		"drizzle-orm": "^0.29.0",
+		"drizzle-orm": "^0",
 		"lucia": "workspace:*",
 		"mysql2": "^3.2.3",
 		"pg": "^8.8.0",


### PR DESCRIPTION
Mark drizzle-orm as a peer dep so you don't get type issues when using the adapters that have different versions of drizzle-orm specified.