### PR TITLE
docs: correct instance name passed to LibSQLAdapter

### DIFF
--- a/docs/pages/database/sqlite.md
+++ b/docs/pages/database/sqlite.md
@@ -95,7 +95,7 @@ declare module "lucia" {
 
 ### LibSQL
 
-`LibSQLAdapter` takes a `D1Database` instance and a list of table names.
+`LibSQLAdapter` takes a `Client` instance and a list of table names.
 
 ```ts
 import { Lucia } from "lucia";


### PR DESCRIPTION
Currently, docs for SQLite at [https://lucia-auth.com/database/sqlite](https://lucia-auth.com/database/sqlite) shows a description under LibSQL as:

`LibSQLAdapter takes a D1Database instance and a list of table names.`

However, we pass a Client instance to it.

https://github.com/lucia-auth/lucia/blob/d285a08dc2eda428236a1b267b19c01886e786ad/packages/adapter-sqlite/src/drivers/libsql.ts#L7C18-L7C24

This PR fixes it.
