### PR TITLE
docs: fix typo in custom user attributes docs

### DIFF
--- a/docs/pages/basics/users.md
+++ b/docs/pages/basics/users.md
@@ -39,7 +39,7 @@ const id = generateRandomString(15, alphabet("a-z", "A-Z", "0-9"));
 
 ## Define user attributes
 
-Defining custom session attributes requires 2 steps. First, add the required columns to the user table. You can type it by declaring the `Register.DatabaseUserAttributes` type (must be an interface).
+Defining custom user attributes requires 2 steps. First, add the required columns to the user table. You can type it by declaring the `Register.DatabaseUserAttributes` type (must be an interface).
 
 ```ts
 declare module "lucia" {


### PR DESCRIPTION
This fixes what I believe was a small copy/paste typo that gave me a quick second of confusion while working through the docs.

The section is "Define user attributes" and the first sentence describes defining custom session attributes.