### PR TITLE
Use `strict-origin` referrer policy

### DIFF
--- a/docs/pages/guides/email-and-password/email-verification-links.md
+++ b/docs/pages/guides/email-and-password/email-verification-links.md
@@ -160,7 +160,7 @@ app.get("email-verification/:token", async () => {
 		headers: {
 			Location: "/",
 			"Set-Cookie": sessionCookie.serialize(),
-			"Referrer-Policy": "no-referrer"
+			"Referrer-Policy": "strict-origin"
 		}
 	});
 });

--- a/docs/pages/guides/email-and-password/password-reset.md
+++ b/docs/pages/guides/email-and-password/password-reset.md
@@ -73,14 +73,14 @@ Make sure to implement rate limiting based on IP addresses.
 
 ## Verify token
 
-Make sure to set the `Referrer-Policy` header of the password reset page to `no-referrer` to protect the token from referrer leakage.
+Make sure to set the `Referrer-Policy` header of the password reset page to `strict-origin` to protect the token from referrer leakage.
 
 ```ts
 app.get("/reset-password/:token", async () => {
 	// ...
 	return new Response(html, {
 		headers: {
-			"Referrer-Policy": "no-referrer"
+			"Referrer-Policy": "strict-origin"
 		}
 	});
 });
@@ -137,7 +137,7 @@ app.post("/reset-password/:token", async () => {
 		headers: {
 			Location: "/",
 			"Set-Cookie": sessionCookie.serialize(),
-			"Referrer-Policy": "no-referrer"
+			"Referrer-Policy": "strict-origin"
 		}
 	});
 });


### PR DESCRIPTION
Using `no-referrer` blocks the browser from sending the `Origin` header as well