### PR TITLE
docs: fix code sample for validating sessions in express.

### DIFF
--- a/docs/pages/guides/validate-session-cookies/express.md
+++ b/docs/pages/guides/validate-session-cookies/express.md
@@ -25,6 +25,7 @@ app.use((req, res, next) => {
 	if (!originHeader || !hostHeader || !verifyRequestOrigin(originHeader, [hostHeader])) {
 		return res.status(403).end();
 	}
+	return next();
 });
 
 app.use((req, res, next) => {


### PR DESCRIPTION
In the code sample for validating session in express, before validating there is a middleware that verify the request origins. However, in that middleware, once every is verified and valid for an non-GET request, it forgets to return the value of the next function. Without this, any non-GET requests that has valid request origins will stall. 