### PR TITLE
bug: remove boolean flip on session validation

### DIFF
--- a/packages/lucia/src/core.ts
+++ b/packages/lucia/src/core.ts
@@ -142,7 +142,7 @@ export class Lucia<
 			fresh: false,
 			expiresAt: databaseSession.expiresAt
 		};
-		if (!isWithinExpirationDate(activePeriodExpirationDate)) {
+		if (isWithinExpirationDate(activePeriodExpirationDate)) {
 			session.fresh = true;
 			session.expiresAt = createDate(this.sessionExpiresIn);
 			await this.adapter.updateSessionExpiration(databaseSession.id, session.expiresAt);


### PR DESCRIPTION
Remove boolean flip on validateSession when evaluating if the current date is before the mid way point to the session expiration date. This addresses: https://github.com/lucia-auth/lucia/issues/1681#issue-2496502719