### PR TITLE
Add missing import to SvelteKit getting started

### DIFF
--- a/docs/pages/getting-started/sveltekit.md
+++ b/docs/pages/getting-started/sveltekit.md
@@ -20,6 +20,7 @@ Import `Lucia` and initialize it with your adapter. Refer to the [Database](/dat
 // src/lib/server/auth.ts
 import { Lucia } from "lucia";
 import { dev } from "$app/environment";
+import { BetterSqlite3Adapter } from "@lucia-auth/adapter-sqlite";
 
 const adapter = new BetterSQLite3Adapter(db); // your adapter
 


### PR DESCRIPTION
The code snippet in the SvelteKit getting started tutorial is missing the import for BetterSqlite3Adapter, which may be confusing to new users. This adds the import to resolve the issue.