### PR TITLE
Getting started guides: example and style fixes

### DIFF
--- a/docs/pages/getting-started/astro.md
+++ b/docs/pages/getting-started/astro.md
@@ -6,7 +6,7 @@ title: "Getting started in Astro"
 
 ## Installation
 
-Install Lucia using your package manager of your choice.
+Install Lucia using your package manager of your choice, for example with npm:
 
 ```
 npm install lucia
@@ -32,23 +32,30 @@ If you're using version below 4.9, you must [manually implement CSRF protection]
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
 
 ```ts
 // src/auth.ts
 import { Lucia } from "lucia";
+import { BetterSqlite3Adapter } from "@lucia-auth/adapter-sqlite";
+import { db } from './db'
 
-const adapter = new BetterSQLite3Adapter(db); // your adapter
+// configure adapter database and auth tables
+const adapter = new BetterSqlite3Adapter(db, {
+	user: "user",
+	session: "session"
+});
 
+// configure the session cookie behavior
 export const lucia = new Lucia(adapter, {
 	sessionCookie: {
 		attributes: {
-			// set to `true` when using HTTPS
-			secure: import.meta.env.PROD
+			secure: import.meta.env.PROD // 'true' when using HTTPS
 		}
 	}
 });
 
+// register your 'Lucia' instance type
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;

--- a/docs/pages/getting-started/astro.md
+++ b/docs/pages/getting-started/astro.md
@@ -12,6 +12,14 @@ Install Lucia using your package manager of your choice, for example with npm:
 npm install lucia
 ```
 
+In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+
+```
+npm install @lucia-auth/adapter-sqlite
+```
+
+Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter.
+
 ## Enable CSRF protection
 
 Make sure you're using the latest version of Astro and enable CSRF protection.
@@ -32,7 +40,7 @@ If you're using version below 4.9, you must [manually implement CSRF protection]
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+Import Lucia, your adapter and the database and initialize them:
 
 ```ts
 // src/auth.ts

--- a/docs/pages/getting-started/nextjs-app.md
+++ b/docs/pages/getting-started/nextjs-app.md
@@ -6,7 +6,7 @@ title: "Getting started in Next.js App router"
 
 ## Installation
 
-Install Lucia using your package manager of your choice.
+Install Lucia using your package manager of your choice, for example with npm:
 
 ```
 npm install lucia
@@ -14,27 +14,33 @@ npm install lucia
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
 
 ```ts
 // src/auth.ts
 import { Lucia } from "lucia";
+import { BetterSqlite3Adapter } from "@lucia-auth/adapter-sqlite";
+import { db } from './db';
 
-const adapter = new BetterSQLite3Adapter(db); // your adapter
-
-export const lucia = new Lucia(adapter, {
-	sessionCookie: {
-		// this sets cookies with super long expiration
-		// since Next.js doesn't allow Lucia to extend cookie expiration when rendering pages
-		expires: false,
-		attributes: {
-			// set to `true` when using HTTPS
-			secure: process.env.NODE_ENV === "production"
-		}
-	}
+// configure adapter database and auth tables
+const adapter = new BetterSqlite3Adapter(db, {
+	user: "user",
+	session: "session"
 });
 
-// IMPORTANT!
+// configure the session cookie behavior
+export const lucia = new Lucia(adapter, {
+	sessionCookie: {
+		attributes: {
+			secure: process.env.NODE_ENV === "production" // 'true' when using HTTPS
+		},
+		expires: false, // extend expiration time *
+	}
+});
+// * Next.js doesn't allow Lucia to extend cookie 
+// expiration when rendering pages
+
+// register your 'Lucia' instance type
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;

--- a/docs/pages/getting-started/nextjs-app.md
+++ b/docs/pages/getting-started/nextjs-app.md
@@ -12,9 +12,17 @@ Install Lucia using your package manager of your choice, for example with npm:
 npm install lucia
 ```
 
+In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+
+```
+npm install @lucia-auth/adapter-sqlite
+```
+
+Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter.
+
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+Import Lucia, your adapter and the database and initialize them:
 
 ```ts
 // src/auth.ts

--- a/docs/pages/getting-started/nextjs-pages.md
+++ b/docs/pages/getting-started/nextjs-pages.md
@@ -12,9 +12,17 @@ Install Lucia using your package manager of your choice, for example with npm:
 npm install lucia
 ```
 
+In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+
+```
+npm install @lucia-auth/adapter-sqlite
+```
+
+Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter.
+
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+Import Lucia, your adapter and the database and initialize them:
 
 ```ts
 // src/auth.ts

--- a/docs/pages/getting-started/nextjs-pages.md
+++ b/docs/pages/getting-started/nextjs-pages.md
@@ -6,7 +6,7 @@ title: "Getting started in Next.js Pages router"
 
 ## Installation
 
-Install Lucia using your package manager of your choice.
+Install Lucia using your package manager of your choice, for example with npm:
 
 ```
 npm install lucia
@@ -14,24 +14,30 @@ npm install lucia
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
 
 ```ts
 // src/auth.ts
 import { Lucia } from "lucia";
+import { BetterSqlite3Adapter } from "@lucia-auth/adapter-sqlite";
+import { db } from './db';
 
-const adapter = new BetterSQLite3Adapter(db); // your adapter
+// configure adapter database and auth tables
+const adapter = new BetterSqlite3Adapter(db, {
+	user: "user",
+	session: "session"
+});
 
+// configure the session cookie behavior
 export const lucia = new Lucia(adapter, {
 	sessionCookie: {
 		attributes: {
-			// set to `true` when using HTTPS
-			secure: process.env.NODE_ENV === "production"
+			secure: process.env.NODE_ENV === "production" // 'true' when using HTTPS
 		}
 	}
 });
 
-// IMPORTANT!
+// register your 'Lucia' instance type
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;

--- a/docs/pages/getting-started/nuxt.md
+++ b/docs/pages/getting-started/nuxt.md
@@ -12,9 +12,17 @@ Install Lucia using your package manager of your choice, for example with npm:
 npm install lucia
 ```
 
+In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+
+```
+npm install @lucia-auth/adapter-sqlite
+```
+
+Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter.
+
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+Import Lucia, your adapter and the database and initialize them:
 
 ```ts
 // server/utils/auth.ts

--- a/docs/pages/getting-started/nuxt.md
+++ b/docs/pages/getting-started/nuxt.md
@@ -6,7 +6,7 @@ title: "Getting started in Nuxt"
 
 ## Installation
 
-Install Lucia using your package manager of your choice.
+Install Lucia using your package manager of your choice, for example with npm:
 
 ```
 npm install lucia
@@ -14,28 +14,30 @@ npm install lucia
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure you configure the `sessionCookie` option and register your `Lucia` instance type.
-
--   Configure the `sessionCookie` option
--   Register your `Lucia` instance type
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
 
 ```ts
 // server/utils/auth.ts
 import { Lucia } from "lucia";
+import { BetterSqlite3Adapter } from "@lucia-auth/adapter-sqlite";
+import { db } from './db';
 
-const adapter = new BetterSQLite3Adapter(db); // your adapter
+// configure adapter database and auth tables
+const adapter = new BetterSqlite3Adapter(db, {
+	user: "user",
+	session: "session"
+});
 
+// configure the session cookie behavior
 export const lucia = new Lucia(adapter, {
 	sessionCookie: {
-		// IMPORTANT!
 		attributes: {
-			// set to `true` when using HTTPS
-			secure: !process.dev
+			secure: !process.dev // 'true' when using HTTPS
 		}
 	}
 });
 
-// IMPORTANT!
+// register your 'Lucia' instance type
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;

--- a/docs/pages/getting-started/solidstart.md
+++ b/docs/pages/getting-started/solidstart.md
@@ -6,7 +6,7 @@ title: "Getting started in SolidStart"
 
 ## Installation
 
-Install Lucia using your package manager of your choice.
+Install Lucia using your package manager of your choice, for example with npm:
 
 ```
 npm install lucia
@@ -14,23 +14,30 @@ npm install lucia
 
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the adapter. Make sure to configure the `sessionCookie` option and register your `Lucia` instance type
+Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
 
 ```ts
 // src/lib/auth.ts
 import { Lucia } from "lucia";
+import { BetterSqlite3Adapter } from "@lucia-auth/adapter-sqlite";
+import { db } from './db'
 
-const adapter = new BetterSQLite3Adapter(db); // your adapter
+// configure adapter database and auth tables
+const adapter = new BetterSqlite3Adapter(db, {
+	user: "user",
+	session: "session"
+});
 
+// configure the session cookie behavior
 export const lucia = new Lucia(adapter, {
 	sessionCookie: {
 		attributes: {
-			// set to `true` when using HTTPS
-			secure: import.meta.env.PROD
+			secure: import.meta.env.PROD // 'true' when using HTTPS
 		}
 	}
 });
 
+// register your 'Lucia' instance type
 declare module "lucia" {
 	interface Register {
 		Lucia: typeof lucia;

--- a/docs/pages/getting-started/solidstart.md
+++ b/docs/pages/getting-started/solidstart.md
@@ -12,9 +12,17 @@ Install Lucia using your package manager of your choice, for example with npm:
 npm install lucia
 ```
 
+In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+
+```
+npm install @lucia-auth/adapter-sqlite
+```
+
+Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter.
+
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+Import Lucia, your adapter and the database and initialize them:
 
 ```ts
 // src/lib/auth.ts

--- a/docs/pages/getting-started/sveltekit.md
+++ b/docs/pages/getting-started/sveltekit.md
@@ -12,9 +12,17 @@ Install Lucia using your package manager of your choice, for example with npm:
 npm install -D lucia
 ```
 
+In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+
+```
+npm install -D @lucia-auth/adapter-sqlite
+```
+
+Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter.
+
 ## Initialize Lucia
 
-Import `Lucia` and initialize it with your adapter. Refer to the [Database](/database) page to learn how to set up your database and initialize the appropriate adapter. In this quickstart, we use the [SQLite adapter](/database/sqlite), but you can easily substitute another adapter:
+Import Lucia, your adapter and the database and initialize them:
 
 ```ts
 // src/lib/server/auth.ts


### PR DESCRIPTION
This addresses several issues with the SvelteKit getting started guide.

Initialize Lucia:
  1. Explicitly explain that SQLite is used in the example and that its easy to substitute other adapters
  2. Fix the naming of the adapter: BetterSQLite3Adapter => BetterSqlite3Adapter
  3. Add explicit imports for the adapter and db
  4. Inline comments to explain all steps, rather than partial explanation of only part of the steps

Setup hooks:
  1. Explain the purpose of the hook in more detail in the intro paragraph
  2. Inline comments to explain all the steps
  3. Move the link to external documentation to the end of the section, improving the flow (since its non-essential)

Other minor style adjustments are made in other sections.