### PR TITLE
Update "API Routes" to "Route Handlers" in Next.js App Router documentation

### DIFF
--- a/docs/pages/guides/validate-session-cookies/nextjs-app.md
+++ b/docs/pages/guides/validate-session-cookies/nextjs-app.md
@@ -8,7 +8,7 @@ You can get the cookie name with `Lucia.sessionCookieName` and validate the sess
 
 We recommend wrapping the function with [`cache()`](https://nextjs.org/docs/app/building-your-application/caching#react-cache-function) so it can be called multiple times without incurring multiple database calls.
 
-**CSRF protection is only handled by Next.js when using form actions.** If you're using API routes, it must be implemented by yourself (see below).
+**CSRF protection is only handled by Next.js when using form actions.** If you're using Route Handlers, it must be implemented by yourself (see below).
 
 ```ts
 import { lucia } from "@/utils/auth";
@@ -74,7 +74,7 @@ async function Page() {
 }
 ```
 
-For API routes, since Next.js does not implement CSRF protection for API routes, **CSRF protection must be implemented when dealing with forms** if you're dealing with forms. This can be easily done by comparing the `Origin` and `Host` header. We recommend using middleware for this.
+For Route Handlers, since Next.js does not implement CSRF protection for Route Handlers, **CSRF protection must be implemented when dealing with forms** if you're dealing with forms. This can be easily done by comparing the `Origin` and `Host` header. We recommend using middleware for this.
 
 ```ts
 // middleware.ts

--- a/docs/pages/tutorials/github-oauth/nextjs-app.md
+++ b/docs/pages/tutorials/github-oauth/nextjs-app.md
@@ -99,7 +99,7 @@ export default async function Page() {
 
 ## Create authorization URL
 
-Create an API route in `app/login/github/route.ts`. Generate a new state, create a new authorization URL with createAuthorizationURL(), store the state, and redirect the user to the authorization URL. The user will be prompted to sign in with GitHub.
+Create an Route Handlers in `app/login/github/route.ts`. Generate a new state, create a new authorization URL with createAuthorizationURL(), store the state, and redirect the user to the authorization URL. The user will be prompted to sign in with GitHub.
 
 ```ts
 // app/login/github/route.ts
@@ -125,7 +125,7 @@ export async function GET(): Promise<Response> {
 
 ## Validate callback
 
-Create an API route in `app/login/github/callback/route.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
+Create an Route Handlers in `app/login/github/callback/route.ts` to handle the callback. First, get the state from the cookie and the search params and compare them. Validate the authorization code in the search params with `validateAuthorizationCode()`. This will throw an [`OAuth2RequestError`](https://oslo.js.org/reference/oauth2/OAuth2RequestError) if the code or credentials are invalid. After validating the code, get the user's profile using the access token. Check if the user is already registered with the GitHub ID, and create a new user if they aren't. Finally, create a new session and set the session cookie.
 
 ```ts
 // app/login/github/callback/route.ts
@@ -211,7 +211,7 @@ interface GitHubUser {
 
 Create `validateRequest()`. This will check for the session cookie, validate it, and set a new cookie if necessary. Make sure to catch errors when setting cookies and wrap the function with `cache()` to prevent unnecessary database calls. To learn more, see the [Validating requests](/guides/validate-session-cookies/nextjs-app) page.
 
-CSRF protection should be implemented but Next.js handles it when using form actions (but not for API routes).
+CSRF protection should be implemented but Next.js handles it when using form actions (but not for Route Handlers).
 
 ```ts
 import { cookies } from "next/headers";

--- a/docs/pages/tutorials/username-and-password/nextjs-app.md
+++ b/docs/pages/tutorials/username-and-password/nextjs-app.md
@@ -265,7 +265,7 @@ async function login(_: any, formData: FormData): Promise<ActionResult> {
 
 Create `validateRequest()`. This will check for the session cookie, validate it, and set a new cookie if necessary. Make sure to catch errors when setting cookies and wrap the function with `cache()` to prevent unnecessary database calls. To learn more, see the [Validating requests](/guides/validate-session-cookies/nextjs-app) page.
 
-CSRF protection should be implemented but Next.js handles it when using form actions (but not for API routes).
+CSRF protection should be implemented but Next.js handles it when using form actions (but not for Route Handlers).
 
 ```ts
 import { cookies } from "next/headers";


### PR DESCRIPTION
# Update "API Routes" to "Route Handlers" in Next.js App Router documentation

## Description
This PR updates the terminology in the Next.js App Router documentation from "API Routes" to "Route Handlers". This change aligns the documentation with the current Next.js terminology, improving clarity and consistency for users implementing authentication with the App Router.

## Changes
- Updated the following files:
  1. `nextjs-app.md` (Validate session cookies guide)
  2. `nextjs-app.md` (GitHub OAuth guide)
  3. `nextjs-app.md` (Username and password auth guide)
- Replaced all instances of "API Routes" with "Route Handlers"

## Example of changes
Before:
```markdown
Create an API routes in `app/login/github/route.ts`.
```

After:
```markdown
Create a Route Handlers in `app/login/github/route.ts`.
```

## Motivation
The current documentation uses outdated terminology from the Pages Router, which may confuse users implementing authentication with the newer App Router. This update ensures the documentation accurately reflects the current Next.js best practices.

## Additional Notes
- This is a minor terminology update and does not change any functionality or code examples.
- The changes are limited in scope, focusing only on updating the "API Routes" terminology.
- File paths and other content remain unchanged.

I believe this small change aligns with the project's goals of maintaining simplicity and clarity in the documentation. If any adjustments are needed or if you'd prefer a different approach, please let me know.