### PR TITLE
Removing redundant not nulls from primary key rows for drizzle/sqlite docs and adapter

### DIFF
--- a/docs/pages/database/drizzle.md
+++ b/docs/pages/database/drizzle.md
@@ -98,11 +98,11 @@ const sqliteDB = sqlite(":memory:");
 const db = drizzle(sqliteDB);
 
 const userTable = sqliteTable("user", {
-	id: text("id").notNull().primaryKey()
+	id: text("id").primaryKey()
 });
 
 const sessionTable = sqliteTable("session", {
-	id: text("id").notNull().primaryKey(),
+	id: text("id").primaryKey(),
 	userId: text("user_id")
 		.notNull()
 		.references(() => userTable.id),

--- a/packages/adapter-drizzle/tests/sqlite.ts
+++ b/packages/adapter-drizzle/tests/sqlite.ts
@@ -24,12 +24,12 @@ sqliteDB
 	.run(databaseUser.id, databaseUser.attributes.username);
 
 const userTable = sqliteTable("user", {
-	id: text("id").notNull().primaryKey(),
+	id: text("id").primaryKey(),
 	username: text("username").notNull().unique()
 });
 
 const sessionTable = sqliteTable("user_session", {
-	id: text("id").notNull().primaryKey(),
+	id: text("id").primaryKey(),
 	userId: text("user_id")
 		.notNull()
 		.references(() => userTable.id),


### PR DESCRIPTION
SQLite applies not null constraint automatically for primary key rows and so not null is redundant. 

Drizzle supports this behavior for SQLite, PG, and MySQL - https://orm.drizzle.team/docs/indexes-constraints#primary-key

Removed redundant instance of notNull() in context of primaryKey(), from docs and adapter to better match existing PG and MySQL examples. 

(This is my first PR so unsure if this is useful / appropriate.)