### PR TITLE
Docs: fix typo to match file name in code example

### DIFF
--- a/docs/pages/database/drizzle.md
+++ b/docs/pages/database/drizzle.md
@@ -98,11 +98,11 @@ const sqliteDB = sqlite(":memory:");
 const db = drizzle(sqliteDB);
 
 const userTable = sqliteTable("user", {
-	id: text("id").notNull().primaryKey()
+	id: text("id").primaryKey()
 });
 
 const sessionTable = sqliteTable("session", {
-	id: text("id").notNull().primaryKey(),
+	id: text("id").primaryKey(),
 	userId: text("user_id")
 		.notNull()
 		.references(() => userTable.id),

--- a/docs/pages/tutorials/username-and-password/nextjs-pages.md
+++ b/docs/pages/tutorials/username-and-password/nextjs-pages.md
@@ -209,7 +209,7 @@ export default function Page() {
 }
 ```
 
-Create an API route as `pages/api/signup.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route as `pages/api/login.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // pages/api/login.ts

--- a/packages/adapter-drizzle/tests/sqlite.ts
+++ b/packages/adapter-drizzle/tests/sqlite.ts
@@ -24,12 +24,12 @@ sqliteDB
 	.run(databaseUser.id, databaseUser.attributes.username);
 
 const userTable = sqliteTable("user", {
-	id: text("id").notNull().primaryKey(),
+	id: text("id").primaryKey(),
 	username: text("username").notNull().unique()
 });
 
 const sessionTable = sqliteTable("user_session", {
-	id: text("id").notNull().primaryKey(),
+	id: text("id").primaryKey(),
 	userId: text("user_id")
 		.notNull()
 		.references(() => userTable.id),


### PR DESCRIPTION
"pages/api/signup.ts" should be "pages/api/login.ts" to match the intended code snippet.