### PR TITLE
Docs: fix typo to match file name to code example

### DIFF
--- a/docs/pages/tutorials/username-and-password/nextjs-pages.md
+++ b/docs/pages/tutorials/username-and-password/nextjs-pages.md
@@ -209,7 +209,7 @@ export default function Page() {
 }
 ```
 
-Create an API route as `pages/api/signup.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
+Create an API route as `pages/api/login.ts`. First, do a very basic input validation. Get the user with the username and verify the password. If successful, create a new session with `Lucia.createSession()` and set a new session cookie.
 
 ```ts
 // pages/api/login.ts


### PR DESCRIPTION
"pages/api/signup.ts" should be "pages/api/login.ts" to match the intended code snippet.