### PR TITLE
fix: `Expires` cookie being larger than 400 days

### DIFF
--- a/packages/lucia/src/core.ts
+++ b/packages/lucia/src/core.ts
@@ -81,7 +81,7 @@ export class Lucia<
 		this.sessionCookieName = options?.sessionCookie?.name ?? "auth_session";
 		let sessionCookieExpiresIn = this.sessionExpiresIn;
 		if (options?.sessionCookie?.expires === false) {
-			sessionCookieExpiresIn = new TimeSpan(365 * 2, "d");
+			sessionCookieExpiresIn = new TimeSpan(400, "d");
 		}
 		const baseSessionCookieAttributes: CookieAttributes = {
 			httpOnly: true,


### PR DESCRIPTION
I was experiencing some issues when using `expires: false` in my `sessionCookie` with Hono, as it now throws an error [under cases where `Expires` or `maxAge` exceed 400 days from now](https://hono.dev/docs/helpers/cookie#following-the-best-practices). Their reasoning behind this error is due to following [this RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-13#section-4.1.2.1).

This PR should hopefully fix the error from being thrown and help prevent unwanted behaviour. Even on browser-side.

Related PRs (better spoken ones):
honojs/hono#2762
supabase/ssr#37
supabase/ssr#54