### PR TITLE
docs: add note about not using validateRequest() in layout.tsx on app…

### DIFF
--- a/docs/pages/tutorials/github-oauth/nextjs-app.md
+++ b/docs/pages/tutorials/github-oauth/nextjs-app.md
@@ -248,7 +248,7 @@ export const validateRequest = cache(
 );
 ```
 
-This function can then be used in server components and form actions to get the current session and user.
+This function can then be used in server components and form actions to get the current session and user. 
 
 ```tsx
 import { redirect } from "next/navigation";
@@ -262,6 +262,8 @@ export default async function Page() {
 	return <h1>Hi, {user.username}!</h1>;
 }
 ```
+
+> Note: This code is not suitable for use in `layout.tsx` files. Layouts do not re-render on page transitions, so the authentication check won't run for each route change.
 
 ## Sign out
 

--- a/docs/pages/tutorials/username-and-password/nextjs-app.md
+++ b/docs/pages/tutorials/username-and-password/nextjs-app.md
@@ -317,6 +317,8 @@ export default async function Page() {
 }
 ```
 
+> Note: This code is not suitable for use in `layout.tsx` files. Layouts do not re-render on page transitions, so the authentication check won't run for each route change.
+
 ## Sign out
 
 Sign out users by invalidating their session with `Lucia.invalidateSession()`. Make sure to remove their session cookie by setting a blank session cookie created with `Lucia.createBlankSessionCookie()`.


### PR DESCRIPTION
Adding a note about not using `validateRequest()` in `layout.tsx` files. As it might suprise someone that layouts do not re-render on page transitions, so the authentication check won't run for each route change. 