### PR TITLE
docs: fix Promise<void> type for async invalidateSession in DrizzleORM docs

### DIFF
--- a/pages/sessions/basic-api/drizzle-orm.md
+++ b/pages/sessions/basic-api/drizzle-orm.md
@@ -231,7 +231,7 @@ import { db, userTable, sessionTable } from "./db.js";
 
 // ...
 
-export async function invalidateSession(sessionId: string): void {
+export async function invalidateSession(sessionId: string): Promise<void> {
 	await db.delete(sessionTable).where(eq(sessionTable.id, sessionId));
 }
 ```


### PR DESCRIPTION
Drizzle-ORM Basic API documentation page incorrectly uses type `void` for `async` function in the implementation of `invalidateSession`. However, it is correctly noted as `Promise<void>` above; this PR simply changes the type to match the previous type and include code which can compile.