### PR TITLE
docs: typo in astro csrf protection codeblock

### DIFF
--- a/pages/sessions/cookies/astro.md
+++ b/pages/sessions/cookies/astro.md
@@ -15,7 +15,7 @@ CSRF protection is a must when using cookies. From Astro v5.0, basic CSRF protec
 export default defineConfig({
 	output: "server",
 	security: {
-		checkOrigin: false
+		checkOrigin: true
 	}
 });
 ```


### PR DESCRIPTION
The value of security.checkOrigin should be 'true' to enable CSRF protection. This seems to be a typo in the docs.