### PR TITLE
Update Next.js: Refactor to Asynchronous `cookies()` API

### DIFF
--- a/pages/sessions/cookies/nextjs.md
+++ b/pages/sessions/cookies/nextjs.md
@@ -63,7 +63,8 @@ import { cookies } from "next/headers";
 // ...
 
 export async function setSessionTokenCookie(token: string, expiresAt: Date): Promise<void> {
-	(await cookies()).set("session", token, {
+	const cookieStore = await cookies();
+	cookieStore.set("session", token, {
 		httpOnly: true,
 		sameSite: "lax",
 		secure: process.env.NODE_ENV === "production",
@@ -73,7 +74,8 @@ export async function setSessionTokenCookie(token: string, expiresAt: Date): Pro
 }
 
 export async function deleteSessionTokenCookie(): Promise<void> {
-	(await cookies()).set("session", "", {
+	const cookieStore = await cookies();
+	cookieStore.set("session", "", {
 		httpOnly: true,
 		sameSite: "lax",
 		secure: process.env.NODE_ENV === "production",
@@ -83,7 +85,7 @@ export async function deleteSessionTokenCookie(): Promise<void> {
 }
 ```
 
-> Before Next.js 15, `cookies()` was synchronous. If you are using an older version, you should replace `(await cookies())` with `cookies()`, switch the return type to `void`, and remove the `async` keyword.
+> Before Next.js 15, `cookies()` was synchronous. If you are using an older version, you should replace `await cookies()` with `cookies()`. You should also switch the function return type to `void`, and remove the `async` keyword.
 
 Since we can't extend set cookies insides server components due to a limitation with React, we recommend continuously extending the cookie expiration inside middleware. However, this comes with its own issue. We can't detect if a new cookie was set inside server actions or route handlers from middleware. This becomes an issue if we need to assign a new session inside server actions (e.g. after updating the password) as the middleware cookie will override it. As such, we'll only extend the cookie expiration on GET requests.
 
@@ -156,7 +158,8 @@ import { cache } from "react";
 // ...
 
 export const getCurrentSession = cache(async (): Promise<SessionValidationResult> => {
-	const token = (await cookies()).get("session")?.value ?? null;
+	const cookieStore = await cookies();
+	const token = cookieStore.get("session")?.value ?? null;
 	if (token === null) {
 		return { session: null, user: null };
 	}
@@ -165,7 +168,7 @@ export const getCurrentSession = cache(async (): Promise<SessionValidationResult
 });
 ```
 
-> On versions of Next.js below 15, replace `(await cookies())` with `cookies()`.
+> On versions of Next.js below 15, replace `await cookies()` with `cookies()`.
 
 This function can be used in server components, server actions, and route handlers (but importantly not middleware).
 

--- a/pages/sessions/cookies/nextjs.md
+++ b/pages/sessions/cookies/nextjs.md
@@ -62,8 +62,8 @@ import { cookies } from "next/headers";
 
 // ...
 
-export function setSessionTokenCookie(token: string, expiresAt: Date): void {
-	cookies().set("session", token, {
+export async function setSessionTokenCookie(token: string, expiresAt: Date): Promise<void> {
+	(await cookies()).set("session", token, {
 		httpOnly: true,
 		sameSite: "lax",
 		secure: process.env.NODE_ENV === "production",
@@ -72,8 +72,8 @@ export function setSessionTokenCookie(token: string, expiresAt: Date): void {
 	});
 }
 
-export function deleteSessionTokenCookie(): void {
-	cookies().set("session", "", {
+export async function deleteSessionTokenCookie(): Promise<void> {
+	(await cookies()).set("session", "", {
 		httpOnly: true,
 		sameSite: "lax",
 		secure: process.env.NODE_ENV === "production",
@@ -82,6 +82,8 @@ export function deleteSessionTokenCookie(): void {
 	});
 }
 ```
+
+> Before Next.js 15, `cookies()` was synchronous. If you are using an older version, you should replace `(await cookies())` with `cookies()`, switch the return type to `void`, and remove the `async` keyword.
 
 Since we can't extend set cookies insides server components due to a limitation with React, we recommend continuously extending the cookie expiration inside middleware. However, this comes with its own issue. We can't detect if a new cookie was set inside server actions or route handlers from middleware. This becomes an issue if we need to assign a new session inside server actions (e.g. after updating the password) as the middleware cookie will override it. As such, we'll only extend the cookie expiration on GET requests.
 
@@ -154,7 +156,7 @@ import { cache } from "react";
 // ...
 
 export const getCurrentSession = cache(async (): Promise<SessionValidationResult> => {
-	const token = cookies().get("session")?.value ?? null;
+	const token = (await cookies()).get("session")?.value ?? null;
 	if (token === null) {
 		return { session: null, user: null };
 	}
@@ -162,6 +164,8 @@ export const getCurrentSession = cache(async (): Promise<SessionValidationResult
 	return result;
 });
 ```
+
+> On versions of Next.js below 15, replace `(await cookies())` with `cookies()`.
 
 This function can be used in server components, server actions, and route handlers (but importantly not middleware).
 

--- a/pages/tutorials/github-oauth/nextjs.md
+++ b/pages/tutorials/github-oauth/nextjs.md
@@ -84,7 +84,7 @@ export async function GET(): Promise<Response> {
 	const state = generateState();
 	const url = github.createAuthorizationURL(state, []);
 
-	cookies().set("github_oauth_state", state, {
+	(await cookies()).set("github_oauth_state", state, {
 		path: "/",
 		secure: process.env.NODE_ENV === "production",
 		httpOnly: true,
@@ -117,7 +117,7 @@ export async function GET(request: Request): Promise<Response> {
 	const url = new URL(request.url);
 	const code = url.searchParams.get("code");
 	const state = url.searchParams.get("state");
-	const storedState = cookies().get("github_oauth_state")?.value ?? null;
+	const storedState = (await cookies()).get("github_oauth_state")?.value ?? null;
 	if (code === null || state === null || storedState === null) {
 		return new Response(null, {
 			status: 400

--- a/pages/tutorials/github-oauth/nextjs.md
+++ b/pages/tutorials/github-oauth/nextjs.md
@@ -84,7 +84,8 @@ export async function GET(): Promise<Response> {
 	const state = generateState();
 	const url = github.createAuthorizationURL(state, []);
 
-	(await cookies()).set("github_oauth_state", state, {
+	const cookieStore = await cookies();
+	cookieStore.set("github_oauth_state", state, {
 		path: "/",
 		secure: process.env.NODE_ENV === "production",
 		httpOnly: true,
@@ -117,7 +118,8 @@ export async function GET(request: Request): Promise<Response> {
 	const url = new URL(request.url);
 	const code = url.searchParams.get("code");
 	const state = url.searchParams.get("state");
-	const storedState = (await cookies()).get("github_oauth_state")?.value ?? null;
+	const cookieStore = await cookies();
+	const storedState = cookieStore.get("github_oauth_state")?.value ?? null;
 	if (code === null || state === null || storedState === null) {
 		return new Response(null, {
 			status: 400

--- a/pages/tutorials/github-oauth/nextjs.md
+++ b/pages/tutorials/github-oauth/nextjs.md
@@ -155,7 +155,7 @@ export async function GET(request: Request): Promise<Response> {
 	if (existingUser !== null) {
 		const sessionToken = generateSessionToken();
 		const session = await createSession(sessionToken, existingUser.id);
-		setSessionTokenCookie(sessionToken, session.expiresAt);
+		await setSessionTokenCookie(sessionToken, session.expiresAt);
 		return new Response(null, {
 			status: 302,
 			headers: {
@@ -169,7 +169,7 @@ export async function GET(request: Request): Promise<Response> {
 
 	const sessionToken = generateSessionToken();
 	const session = await createSession(sessionToken, user.id);
-	setSessionTokenCookie(sessionToken, session.expiresAt);
+	await setSessionTokenCookie(sessionToken, session.expiresAt);
 	return new Response(null, {
 		status: 302,
 		headers: {
@@ -223,7 +223,7 @@ async function logout(): Promise<ActionResult> {
 	}
 
 	await invalidateSession(session.id);
-	deleteSessionTokenCookie();
+	await deleteSessionTokenCookie();
 	return redirect("/login");
 }
 

--- a/pages/tutorials/google-oauth/nextjs.md
+++ b/pages/tutorials/google-oauth/nextjs.md
@@ -83,14 +83,14 @@ export async function GET(): Promise<Response> {
 	const codeVerifier = generateCodeVerifier();
 	const url = google.createAuthorizationURL(state, codeVerifier, ["openid", "profile"]);
 
-	cookies().set("google_oauth_state", state, {
+	(await cookies()).set("google_oauth_state", state, {
 		path: "/",
 		httpOnly: true,
 		secure: process.env.NODE_ENV === "production",
 		maxAge: 60 * 10, // 10 minutes
 		sameSite: "lax"
 	});
-	cookies().set("google_code_verifier", codeVerifier, {
+	(await cookies()).set("google_code_verifier", codeVerifier, {
 		path: "/",
 		httpOnly: true,
 		secure: process.env.NODE_ENV === "production",
@@ -123,8 +123,8 @@ export async function GET(request: Request): Promise<Response> {
 	const url = new URL(request.url);
 	const code = url.searchParams.get("code");
 	const state = url.searchParams.get("state");
-	const storedState = cookies().get("google_oauth_state")?.value ?? null;
-	const codeVerifier = cookies().get("google_code_verifier")?.value ?? null;
+	const storedState = (await cookies()).get("google_oauth_state")?.value ?? null;
+	const codeVerifier = (await cookies()).get("google_code_verifier")?.value ?? null;
 	if (code === null || state === null || storedState === null || codeVerifier === null) {
 		return new Response(null, {
 			status: 400

--- a/pages/tutorials/google-oauth/nextjs.md
+++ b/pages/tutorials/google-oauth/nextjs.md
@@ -157,7 +157,7 @@ export async function GET(request: Request): Promise<Response> {
 	if (existingUser !== null) {
 		const sessionToken = generateSessionToken();
 		const session = await createSession(sessionToken, existingUser.id);
-		setSessionTokenCookie(sessionToken, session.expiresAt);
+		await setSessionTokenCookie(sessionToken, session.expiresAt);
 		return new Response(null, {
 			status: 302,
 			headers: {
@@ -171,7 +171,7 @@ export async function GET(request: Request): Promise<Response> {
 
 	const sessionToken = generateSessionToken();
 	const session = await createSession(sessionToken, user.id);
-	setSessionTokenCookie(sessionToken, session.expiresAt);
+	await setSessionTokenCookie(sessionToken, session.expiresAt);
 	return new Response(null, {
 		status: 302,
 		headers: {
@@ -225,7 +225,7 @@ async function logout(): Promise<ActionResult> {
 	}
 
 	await invalidateSession(session.id);
-	deleteSessionTokenCookie();
+	await deleteSessionTokenCookie();
 	return redirect("/login");
 }
 

--- a/pages/tutorials/google-oauth/nextjs.md
+++ b/pages/tutorials/google-oauth/nextjs.md
@@ -83,14 +83,15 @@ export async function GET(): Promise<Response> {
 	const codeVerifier = generateCodeVerifier();
 	const url = google.createAuthorizationURL(state, codeVerifier, ["openid", "profile"]);
 
-	(await cookies()).set("google_oauth_state", state, {
+	const cookieStore = await cookies();
+	cookieStore.set("google_oauth_state", state, {
 		path: "/",
 		httpOnly: true,
 		secure: process.env.NODE_ENV === "production",
 		maxAge: 60 * 10, // 10 minutes
 		sameSite: "lax"
 	});
-	(await cookies()).set("google_code_verifier", codeVerifier, {
+	cookieStore.set("google_code_verifier", codeVerifier, {
 		path: "/",
 		httpOnly: true,
 		secure: process.env.NODE_ENV === "production",
@@ -123,8 +124,9 @@ export async function GET(request: Request): Promise<Response> {
 	const url = new URL(request.url);
 	const code = url.searchParams.get("code");
 	const state = url.searchParams.get("state");
-	const storedState = (await cookies()).get("google_oauth_state")?.value ?? null;
-	const codeVerifier = (await cookies()).get("google_code_verifier")?.value ?? null;
+	const cookieStore = await cookies();
+	const storedState = cookieStore.get("google_oauth_state")?.value ?? null;
+	const codeVerifier = cookieStore.get("google_code_verifier")?.value ?? null;
 	if (code === null || state === null || storedState === null || codeVerifier === null) {
 		return new Response(null, {
 			status: 400


### PR DESCRIPTION
As of Next.js 15, the `cookies()` API is now asynchronous (see [release notes](https://nextjs.org/blog/next-15#async-request-apis-breaking-change) and [upgrade guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15#async-request-apis-breaking-change)). This PR updates the guide to reflect these changes.

Please let me know if there are any questions or if I need to change anything.