### PR TITLE
fix updated expiresAt in validateSessionToken

### DIFF
--- a/pages/sessions/basic-api/postgresql.md
+++ b/pages/sessions/basic-api/postgresql.md
@@ -148,7 +148,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 	const session: Session = {
 		id: row[0],
 		userId: row[1],
-		expiresAt: new Date(row[2] * 1000)
+		expiresAt: row[3]
 	};
 	const user: User = {
 		id: row[3]
@@ -223,7 +223,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 	const session: Session = {
 		id: row[0],
 		userId: row[1],
-		expiresAt: new Date(row[2] * 1000)
+		expiresAt: row[3]
 	};
 	const user: User = {
 		id: row[3]

--- a/pages/sessions/basic-api/postgresql.md
+++ b/pages/sessions/basic-api/postgresql.md
@@ -148,7 +148,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 	const session: Session = {
 		id: row[0],
 		userId: row[1],
-		expiresAt: row[3]
+		expiresAt: row[2]
 	};
 	const user: User = {
 		id: row[3]
@@ -223,7 +223,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 	const session: Session = {
 		id: row[0],
 		userId: row[1],
-		expiresAt: row[3]
+		expiresAt: row[2]
 	};
 	const user: User = {
 		id: row[3]

--- a/pages/sessions/basic-api/postgresql.md
+++ b/pages/sessions/basic-api/postgresql.md
@@ -161,7 +161,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 		session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 		await db.execute(
 			"UPDATE user_session SET expires_at = ? WHERE id = ?",
-			Math.floor(session.expiresAt / 1000),
+			session.expiresAt,
 			session.id
 		);
 	}
@@ -236,7 +236,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 		session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 		await db.execute(
 			"UPDATE user_session SET expires_at = ? WHERE id = ?",
-			Math.floor(session.expiresAt / 1000),
+			session.expiresAt,
 			session.id
 		);
 	}


### PR DESCRIPTION
There was an error with the validSessionToken function where to update the expiresAt property of the session in the database, the code was converting the date object to a number and even that without using .getTime(). I fixed that by removing unnecessary conversions.