### PR TITLE
fix: null type for session validation result

### DIFF
--- a/pages/sessions/basic-api/postgresql.md
+++ b/pages/sessions/basic-api/postgresql.md
@@ -58,7 +58,8 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 
 export type SessionValidationResult =
 	| { session: Session; user: User }
-	| { session: null; user: null };
+	| { session: null; user: null }
+	| null;
 
 export interface Session {
 	id: string;
@@ -249,7 +250,8 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 
 export type SessionValidationResult =
 	| { session: Session; user: User }
-	| { session: null; user: null };
+	| { session: null; user: null }
+	| null;
 
 export interface Session {
 	id: string;


### PR DESCRIPTION
the session validation result is begin returned as null when the session id is expired but the type for the result doesn't have null. fixed this.