### PR TITLE
Fix: Various errors on MySQL API

### DIFF
--- a/pages/sessions/basic-api/mysql.md
+++ b/pages/sessions/basic-api/mysql.md
@@ -164,7 +164,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 		await db.execute(
 			"UPDATE user_session SET expires_at = ? WHERE id = ?",
 			[
-				Math.floor(session.expiresAt / 1000),
+				Math.floor(session.expiresAt.getTime() / 1000),
 				session.id
 			]
 		);
@@ -243,7 +243,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 		await db.execute(
 			"UPDATE user_session SET expires_at = ? WHERE id = ?",
 			[
-				Math.floor(session.expiresAt / 1000),
+				Math.floor(session.expiresAt.getTime() / 1000),
 				session.id
 			]
 		);

--- a/pages/sessions/basic-api/mysql.md
+++ b/pages/sessions/basic-api/mysql.md
@@ -112,9 +112,11 @@ export async function createSession(token: string, userId: number): Promise<Sess
 	};
 	await db.execute(
 		"INSERT INTO user_session (id, user_id, expires_at) VALUES (?, ?, ?)",
-		session.id,
-		session.userId,
-		session.expiresAt
+		[
+			session.id,
+			session.userId,
+			session.expiresAt
+		]
 	);
 	return session;
 }
@@ -138,7 +140,7 @@ import { sha256 } from "@oslojs/crypto/sha2";
 
 export async function validateSessionToken(token: string): Promise<SessionValidationResult> {
 	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
-	const row = await db.queryOne(
+	const row = await db.query(
 		"SELECT user_session.id, user_session.user_id, user_session.expires_at, user.id FROM user_session INNER JOIN user ON user.id = user_session.user_id WHERE id = ?",
 		sessionId
 	);
@@ -161,8 +163,10 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 		session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 		await db.execute(
 			"UPDATE user_session SET expires_at = ? WHERE id = ?",
-			Math.floor(session.expiresAt / 1000),
-			session.id
+			[
+				Math.floor(session.expiresAt / 1000),
+				session.id
+			]
 		);
 	}
 	return { session, user };
@@ -204,16 +208,18 @@ export async function createSession(token: string, userId: number): Promise<Sess
 	};
 	await db.execute(
 		"INSERT INTO user_session (id, user_id, expires_at) VALUES (?, ?, ?)",
-		session.id,
-		session.userId,
-		session.expiresAt
+		[
+			session.id,
+			session.userId,
+			session.expiresAt
+		]
 	);
 	return session;
 }
 
 export async function validateSessionToken(token: string): Promise<SessionValidationResult> {
 	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
-	const row = await db.queryOne(
+	const row = await db.query(
 		"SELECT user_session.id, user_session.user_id, user_session.expires_at, user.id FROM user_session INNER JOIN user ON user.id = user_session.user_id WHERE id = ?",
 		sessionId
 	);
@@ -236,8 +242,10 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 		session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 		await db.execute(
 			"UPDATE user_session SET expires_at = ? WHERE id = ?",
-			Math.floor(session.expiresAt / 1000),
-			session.id
+			[
+				Math.floor(session.expiresAt / 1000),
+				session.id
+			]
 		);
 	}
 	return { session, user };


### PR DESCRIPTION
1. We should pass an array when we use (more than one) placeholders with mysql2 and .execute() because it accepts only a string.
2.  Also mysql2 doesn't support `queryOne()`.
3.  `session.expiresAT` type is Date and can't be divided by 1000, used `getTime()` to convert type.

[MySQL2 Doc](https://sidorares.github.io/node-mysql2/docs#first-query)
[Interpolating variable issue on Stack overflow](https://stackoverflow.com/questions/3304014/how-to-interpolate-variables-in-strings-in-javascript-without-concatenation)