### PR TITLE
Update drizzle-orm.md

### DIFF
--- a/pages/sessions/basic-api/drizzle-orm.md
+++ b/pages/sessions/basic-api/drizzle-orm.md
@@ -52,11 +52,11 @@ import type { InferSelectModel } from "drizzle-orm";
 const pool = new pg.Pool();
 const db = drizzle(pool);
 
-const userTable = pgTable("user", {
+export const userTable = pgTable("user", {
 	id: serial("id").primaryKey()
 });
 
-const sessionTable = pgTable("session", {
+export const sessionTable = pgTable("session", {
 	id: text("id").primaryKey(),
 	userId: integer("user_id")
 		.notNull()
@@ -83,11 +83,11 @@ import type { InferSelectModel } from "drizzle-orm";
 const sqliteDB = sqlite(":memory:");
 const db = drizzle(sqliteDB);
 
-const userTable = sqliteTable("user", {
+export const userTable = sqliteTable("user", {
 	id: integer("id").primaryKey()
 });
 
-const sessionTable = sqliteTable("session", {
+export const sessionTable = sqliteTable("session", {
 	id: text("id").primaryKey(),
 	userId: integer("user_id")
 		.notNull()


### PR DESCRIPTION
added the missing keyword export, as drizzle-kit was unable to migrate without adding the export.