### PR TITLE
Docs: Prisma example return types and var names

### DIFF
--- a/pages/sessions/basic-api/prisma.md
+++ b/pages/sessions/basic-api/prisma.md
@@ -165,7 +165,7 @@ import { prisma } from "./db.js";
 
 // ...
 
-export async function invalidateSession(sessionId: string): void {
+export async function invalidateSession(sessionId: string): Promise<void> {
 	await prisma.session.delete({ where: { id: sessionId } });
 }
 ```
@@ -231,7 +231,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 	return { session, user };
 }
 
-export async function invalidateSession(sessionId: string): void {
+export async function invalidateSession(sessionId: string): Promise<void> {
 	await db.session.delete({ where: { id: sessionId } });
 }
 

--- a/pages/sessions/basic-api/prisma.md
+++ b/pages/sessions/basic-api/prisma.md
@@ -232,7 +232,7 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 }
 
 export async function invalidateSession(sessionId: string): Promise<void> {
-	await db.session.delete({ where: { id: sessionId } });
+	await prisma.session.delete({ where: { id: sessionId } });
 }
 
 export type SessionValidationResult =


### PR DESCRIPTION
- All async functions return promises
- `db` was written in place of `prisma` in one example