### PR TITLE
feat: Prisma v6 support

### DIFF
--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -39,14 +39,14 @@
 		".": "./dist/index.js"
 	},
 	"peerDependencies": {
-		"@prisma/client": "^4.2.0 || ^5.0.0",
+		"@prisma/client": "^4.2.0 || ^5.0.0 || ^6.0.0",
 		"lucia": "3.x"
 	},
 	"devDependencies": {
 		"lucia": "workspace:*",
 		"@lucia-auth/adapter-test": "workspace:*",
-		"@prisma/client": "^5.0.0",
-		"prisma": "^4.9.0",
+		"@prisma/client": "^6.1.0",
+		"prisma": "^6.1.0",
 		"tsx": "^3.12.6"
 	}
 }


### PR DESCRIPTION
I've updated the `@lucia-auth/adapter-prisma` package to support Prisma 6. I know the Lucia adapters are being deprecated soon, but since we have some time left, I thought I'd get this fix in.

I'm not very experienced with publishing and managing packages on npm, so any guidance or feedback would be appreciated.

Thanks!

___

Addresses https://github.com/lucia-auth/lucia/issues/1758