### PR TITLE
feat: Implement invalidateAllSessions function in Basic API

### DIFF
--- a/pages/sessions/basic-api/drizzle-orm.md
+++ b/pages/sessions/basic-api/drizzle-orm.md
@@ -234,28 +234,17 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 Finally, invalidate sessions by simply deleting it from the database.
 
 ```ts
-import { eq } from "drizzle-orm";
 import { db, userTable, sessionTable } from "./db.js";
+import { eq } from "drizzle-orm";
 
 // ...
 
 export async function invalidateSession(sessionId: string): Promise<void> {
 	await db.delete(sessionTable).where(eq(sessionTable.id, sessionId));
 }
-```
-
-Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
-
-```ts
-import { and, gt, eq } from "drizzle-orm";
-import { db, sessionTable } from "./db.js";
-
-// ...
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-    await db.delete(sessionTable).where(
-        and(eq(sessionTable.userId, userId), gt(sessionTable.expiresAt, new Date()))
-    );
+	await db.delete(sessionTable).where(eq(sessionTable.userId, userId));
 }
 ```
 
@@ -263,7 +252,7 @@ Here's the full code:
 
 ```ts
 import { db, userTable, sessionTable } from "./db.js";
-import { and, gt, eq  } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from "@oslojs/encoding";
 import { sha256 } from "@oslojs/crypto/sha2";
 
@@ -319,9 +308,7 @@ export async function invalidateSession(sessionId: string): void {
 }
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-    await db.delete(sessionTable).where(
-        and(eq(sessionTable.userId, userId), gt(sessionTable.expiresAt, new Date()))
-    );
+	await db.delete(sessionTable).where(eq(sessionTable.userId, userId));
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/drizzle-orm.md
+++ b/pages/sessions/basic-api/drizzle-orm.md
@@ -132,6 +132,10 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 	// TODO
 }
 
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	// TODO
+}
+
 export type SessionValidationResult =
 	| { session: Session; user: User }
 	| { session: null; user: null };
@@ -240,11 +244,26 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 }
 ```
 
+Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
+
+```ts
+import { and, gt, eq } from "drizzle-orm";
+import { db, sessionTable } from "./db.js";
+
+// ...
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+    await db.delete(sessionTable).where(
+        and(eq(sessionTable.userId, userId), gt(sessionTable.expiresAt, new Date()))
+    );
+}
+```
+
 Here's the full code:
 
 ```ts
 import { db, userTable, sessionTable } from "./db.js";
-import { eq } from "drizzle-orm";
+import { and, gt, eq  } from "drizzle-orm";
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from "@oslojs/encoding";
 import { sha256 } from "@oslojs/crypto/sha2";
 
@@ -297,6 +316,12 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 
 export async function invalidateSession(sessionId: string): void {
 	await db.delete(sessionTable).where(eq(sessionTable.id, sessionId));
+}
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+    await db.delete(sessionTable).where(
+        and(eq(sessionTable.userId, userId), gt(sessionTable.expiresAt, new Date()))
+    );
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/mysql.md
+++ b/pages/sessions/basic-api/mysql.md
@@ -183,21 +183,9 @@ import { db } from "./db.js";
 export async function invalidateSession(sessionId: string): Promise<void> {
 	await db.execute("DELETE FROM user_session WHERE id = ?", sessionId);
 }
-```
-
-Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
-
-```ts
-import { db } from "./db.js";
-
-// ...
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-	await db.execute(
-		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
-		userId,
-		new Date()
-	);
+	await db.execute("DELETE FROM user_session WHERE user_id = ?", userId);
 }
 ```
 
@@ -268,11 +256,7 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 }
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-	await db.execute(
-		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
-		userId,
-		new Date()
-	);
+	await db.execute("DELETE FROM user_session WHERE user_id = ?", userId);
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/mysql.md
+++ b/pages/sessions/basic-api/mysql.md
@@ -56,6 +56,10 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 	// TODO
 }
 
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	// TODO
+}
+
 export type SessionValidationResult =
 	| { session: Session; user: User }
 	| { session: null; user: null };
@@ -181,6 +185,23 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 }
 ```
 
+Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
+
+```ts
+import { db } from "./db.js";
+
+// ...
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await db.execute(
+		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
+		userId,
+		new Date()
+	);
+}
+```
+
+
 Here's the full code:
 
 ```ts
@@ -245,6 +266,14 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 
 export async function invalidateSession(sessionId: string): Promise<void> {
 	await db.execute("DELETE FROM user_session WHERE id = ?", sessionId);
+}
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await db.execute(
+		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
+		userId,
+		new Date()
+	);
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/mysql.md
+++ b/pages/sessions/basic-api/mysql.md
@@ -201,7 +201,6 @@ export async function invalidateAllSessions(userId: number): Promise<void> {
 }
 ```
 
-
 Here's the full code:
 
 ```ts

--- a/pages/sessions/basic-api/postgresql.md
+++ b/pages/sessions/basic-api/postgresql.md
@@ -183,21 +183,9 @@ import { db } from "./db.js";
 export async function invalidateSession(sessionId: string): Promise<void> {
 	await db.execute("DELETE FROM user_session WHERE id = ?", sessionId);
 }
-```
-
-Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
-
-```ts
-import { db } from "./db.js";
-
-// ...
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-	await db.execute(
-		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
-		userId,
-		new Date()
-	);
+	await db.execute("DELETE FROM user_session WHERE user_id = ?", userId);
 }
 ```
 
@@ -268,11 +256,7 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 }
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-	await db.execute(
-		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
-		userId,
-		new Date()
-	);
+	await db.execute("DELETE FROM user_session WHERE user_id = ?", userId);
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/postgresql.md
+++ b/pages/sessions/basic-api/postgresql.md
@@ -56,6 +56,10 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 	// TODO
 }
 
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	// TODO
+}
+
 export type SessionValidationResult =
 	| { session: Session; user: User }
 	| { session: null; user: null };
@@ -181,6 +185,22 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 }
 ```
 
+Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
+
+```ts
+import { db } from "./db.js";
+
+// ...
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await db.execute(
+		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
+		userId,
+		new Date()
+	);
+}
+```
+
 Here's the full code:
 
 ```ts
@@ -245,6 +265,14 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 
 export async function invalidateSession(sessionId: string): Promise<void> {
 	await db.execute("DELETE FROM user_session WHERE id = ?", sessionId);
+}
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await db.execute(
+		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
+		userId,
+		new Date()
+	);
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/prisma.md
+++ b/pages/sessions/basic-api/prisma.md
@@ -58,6 +58,10 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 	// TODO
 }
 
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	// TODO
+}
+
 export type SessionValidationResult =
 	| { session: Session; user: User }
 	| { session: null; user: null };
@@ -170,6 +174,25 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 }
 ```
 
+Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
+
+```ts
+import { prisma } from "./db.js";
+
+// ...
+
+export async function invalidateAllSessions(userId: number): Promise <void> {
+    await prisma.session.deleteMany({
+        where: {
+            userId: userId,
+            expiresAt: {
+                gt: new Date(),
+            },
+        },
+    });
+}
+```
+
 Here's the full code:
 
 ```ts
@@ -233,6 +256,17 @@ export async function validateSessionToken(token: string): Promise<SessionValida
 
 export async function invalidateSession(sessionId: string): Promise<void> {
 	await prisma.session.delete({ where: { id: sessionId } });
+}
+
+export async function invalidateAllSessions(userId: number): Promise <void> {
+    await prisma.session.deleteMany({
+        where: {
+            userId: userId,
+            expiresAt: {
+                gt: new Date(),
+            },
+        },
+    });
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/prisma.md
+++ b/pages/sessions/basic-api/prisma.md
@@ -172,24 +172,13 @@ import { prisma } from "./db.js";
 export async function invalidateSession(sessionId: string): Promise<void> {
 	await prisma.session.delete({ where: { id: sessionId } });
 }
-```
 
-Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
-
-```ts
-import { prisma } from "./db.js";
-
-// ...
-
-export async function invalidateAllSessions(userId: number): Promise <void> {
-    await prisma.session.deleteMany({
-        where: {
-            userId: userId,
-            expiresAt: {
-                gt: new Date(),
-            },
-        },
-    });
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await prisma.session.deleteMany({
+		where: {
+			userId: userId
+		}
+	});
 }
 ```
 
@@ -258,15 +247,12 @@ export async function invalidateSession(sessionId: string): Promise<void> {
 	await prisma.session.delete({ where: { id: sessionId } });
 }
 
-export async function invalidateAllSessions(userId: number): Promise <void> {
-    await prisma.session.deleteMany({
-        where: {
-            userId: userId,
-            expiresAt: {
-                gt: new Date(),
-            },
-        },
-    });
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await prisma.session.deleteMany({
+		where: {
+			userId: userId
+		}
+	});
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/redis.md
+++ b/pages/sessions/basic-api/redis.md
@@ -114,16 +114,10 @@ import { sha256 } from "@oslojs/crypto/sha2";
 
 // ...
 
-export async function validateSessionToken(token: string, userId: number): Promise<Session | null> {
+export async function validateSessionToken(token: string): Promise<Session | null> {
 	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
 	const item = await redis.get(`session:${sessionId}`);
 	if (item === null) {
-		return null;
-	}
-
-	const isSessionValidForUser = await redis.sismember(`user_sessions:${userId}`, sessionId);
-	if (isSessionValidForUser !== 1) {
-		await redis.delete(`session:${sessionId}`);
 		return null;
 	}
 
@@ -222,16 +216,10 @@ export async function createSession(token: string, userId: number): Promise<Sess
 	return session;
 }
 
-export async function validateSessionToken(token: string, userId: number): Promise<Session | null> {
+export async function validateSessionToken(token: string): Promise<Session | null> {
 	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
 	const item = await redis.get(`session:${sessionId}`);
 	if (item === null) {
-		return null;
-	}
-
-	const isSessionValidForUser = await redis.sismember(`user_sessions:${userId}`, sessionId);
-	if (isSessionValidForUser !== 1) {
-		await redis.delete(`session:${sessionId}`);
 		return null;
 	}
 

--- a/pages/sessions/basic-api/sqlite.md
+++ b/pages/sessions/basic-api/sqlite.md
@@ -183,24 +183,11 @@ import { db } from "./db.js";
 export function invalidateSession(sessionId: string): void {
 	db.execute("DELETE FROM session WHERE id = ?", sessionId);
 }
-```
-
-Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
-
-```ts
-import { db } from "./db.js";
-
-// ...
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-	await db.execute(
-		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
-		userId,
-		Math.floor(Date.now() / 1000)
-	);
+	await db.execute("DELETE FROM user_session WHERE user_id = ?", userId);
 }
 ```
-
 
 Here's the full code:
 

--- a/pages/sessions/basic-api/sqlite.md
+++ b/pages/sessions/basic-api/sqlite.md
@@ -256,11 +256,7 @@ export function invalidateSession(sessionId: string): void {
 }
 
 export async function invalidateAllSessions(userId: number): Promise<void> {
-	await db.execute(
-		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
-		userId,
-		Math.floor(Date.now() / 1000)
-	);
+	await db.execute("DELETE FROM user_session WHERE user_id = ?", userId);
 }
 
 export type SessionValidationResult =

--- a/pages/sessions/basic-api/sqlite.md
+++ b/pages/sessions/basic-api/sqlite.md
@@ -56,6 +56,10 @@ export function invalidateSession(sessionId: string): void {
 	// TODO
 }
 
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	// TODO
+}
+
 export type SessionValidationResult =
 	| { session: Session; user: User }
 	| { session: null; user: null };
@@ -181,6 +185,23 @@ export function invalidateSession(sessionId: string): void {
 }
 ```
 
+Additionally, we can invalidate all sessions for a specific user by checking their user ID and expiration times.
+
+```ts
+import { db } from "./db.js";
+
+// ...
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await db.execute(
+		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
+		userId,
+		Math.floor(Date.now() / 1000)
+	);
+}
+```
+
+
 Here's the full code:
 
 ```ts
@@ -245,6 +266,14 @@ export function validateSessionToken(token: string): SessionValidationResult {
 
 export function invalidateSession(sessionId: string): void {
 	db.execute("DELETE FROM session WHERE id = ?", sessionId);
+}
+
+export async function invalidateAllSessions(userId: number): Promise<void> {
+	await db.execute(
+		"DELETE FROM user_session WHERE user_id = ? AND expires_at > ?",
+		userId,
+		Math.floor(Date.now() / 1000)
+	);
 }
 
 export type SessionValidationResult =


### PR DESCRIPTION
The purpose of this function is to allow invalidation of all active sessions for a given user.
tasks:
- [x] Implement invalidateAllSessions for MySQL
- [x] Implement invalidateAllSessions for PostgreSQL
- [x] Implement invalidateAllSessions for SQLite
- [x] Implement invalidateAllSessions for Drizzle ORM
- [x] Implement invalidateAllSessions for Prisma
- [x] Implement invalidateAllSessions for Redis