### PR TITLE
docs: fix token-bucket comment value and stateless-tokens JWT encoding example

### DIFF
--- a/pages/rate-limit/token-bucket.md
+++ b/pages/rate-limit/token-bucket.md
@@ -56,7 +56,7 @@ interface Bucket {
 ```
 
 ```ts
-// Bucket that has 10 tokens max and refills at a rate of 30 seconds/token
+// Bucket that has 5 tokens max and refills at a rate of 30 seconds/token
 const ratelimit = new TokenBucketRateLimit<string>(5, 30);
 const valid = ratelimit.consume(ip, 1);
 if (!valid) {

--- a/pages/sessions/stateless-tokens.md
+++ b/pages/sessions/stateless-tokens.md
@@ -87,9 +87,9 @@ async function createSessionJWT(session: Session): Promise<string> {
 		false
 	);
 	const signature = await crypto.subtle.sign("HMAC", hmacCryptoKey, headerAndBodyBytes);
-	const encodedSignature = oslo_jwt.encodeJWT(headerJSON, bodyJSON);
+	const encodedSignature = oslo_encoding.encodeBase64url(new Uint8Array(signature));
 
-	const jw = headerAndBody + "." + encodedSignature;
+	const jwt = headerAndBody + "." + encodedSignature;
 	return jwt;
 }
 


### PR DESCRIPTION
Fixes two documentation bugs found in #1817 and #1815.

## Changes

### `pages/rate-limit/token-bucket.md` (fixes #1817)

The inline comment said "10 tokens max" but the `TokenBucketRateLimit` constructor was called with `5`. Updated comment to match actual code.

### `pages/sessions/stateless-tokens.md` (fixes #1815)

Two bugs in `createSessionJWT()` example:

1. `oslo_jwt.encodeJWT(headerJSON, bodyJSON)` was used to encode the HMAC signature bytes — incorrect. Fixed to `oslo_encoding.encodeBase64url(new Uint8Array(signature))`.
2. Variable was named `jw` but function returned `jwt` (undefined). Renamed to `jwt`.