### PR TITLE
docs: fix token bucket comments and stateless tokens code errors

### DIFF
--- a/pages/rate-limit/token-bucket.md
+++ b/pages/rate-limit/token-bucket.md
@@ -56,7 +56,7 @@ interface Bucket {
 ```
 
 ```ts
-// Bucket that has 10 tokens max and refills at a rate of 30 seconds/token
+// Bucket that has 5 tokens max and refills at a rate of 30 seconds/token
 const ratelimit = new TokenBucketRateLimit<string>(5, 30);
 const valid = ratelimit.consume(ip, 1);
 if (!valid) {
@@ -148,7 +148,7 @@ export class TokenBucketRateLimit {
 ```
 
 ```ts
-// Bucket that has 10 tokens max and refills at a rate of 30 seconds/token
+// Bucket that has 5 tokens max and refills at a rate of 30 seconds/token
 const ratelimit = new TokenBucketRateLimit<string>("ip", 5, 30);
 const valid = await ratelimit.consume(ip, 1);
 if (!valid) {

--- a/pages/sessions/stateless-tokens.md
+++ b/pages/sessions/stateless-tokens.md
@@ -84,12 +84,13 @@ async function createSessionJWT(session: Session): Promise<string> {
 			name: "HMAC",
 			hash: "SHA-256"
 		},
-		false
+		false,
+		["sign"]
 	);
-	const signature = await crypto.subtle.sign("HMAC", hmacCryptoKey, headerAndBodyBytes);
-	const encodedSignature = oslo_jwt.encodeJWT(headerJSON, bodyJSON);
+	const signatureBuffer = await crypto.subtle.sign("HMAC", hmacCryptoKey, headerAndBodyBytes);
+	const encodedSignature = oslo_encoding.encodeBase64url(new Uint8Array(signatureBuffer));
 
-	const jw = headerAndBody + "." + encodedSignature;
+	const jwt = headerAndBody + "." + encodedSignature;
 	return jwt;
 }
 
@@ -133,7 +134,8 @@ async function validateSessionJWT(jwt: string): Promise<ValidatedSession | null>
 			name: "HMAC",
 			hash: "SHA-256"
 		},
-		false
+		false,
+		["verify"]
 	);
 	const validSignature = await crypto.subtle.verify(
 		"HMAC",


### PR DESCRIPTION
Fixes two documentation issues:

### Token Bucket (#1817)
The comments in both usage examples say "10 tokens max" but the constructor argument is `5`. Updated comments to match the actual code.

### Stateless Tokens (#1815)
Three bugs in the `createSessionJWT` function:
1. `crypto.subtle.importKey` was missing the `keyUsages` parameter (`["sign"]` and `["verify"]`). This would throw a TypeError at runtime since Web Crypto API requires this argument.
2. The signature was being encoded with `oslo_jwt.encodeJWT(headerJSON, bodyJSON)` which doesn't exist. Fixed to properly encode the HMAC signature buffer using `oslo_encoding.encodeBase64url(new Uint8Array(signatureBuffer))`.
3. Variable name typo: `jw` should be `jwt`.

Fixes #1815
Fixes #1817