### PR TITLE
Fix CSRF example: compare parsed Origin host instead of raw header

### DIFF
--- a/pages/sessions/basic.md
+++ b/pages/sessions/basic.md
@@ -240,22 +240,28 @@ While the `SameSite` cookie attribute provides some CSRF protection, it doesn't 
 For websites only targeting modern browsers (post-2020), the `Origin` header can be used to check the request origin. Requests without the `Origin` header should be blocked with a status of `403` or similar. Some frameworks already have a similar CSRF protection built in, including Next.js (only for server actions), SvelteKit, and Astro (v5+).
 
 ```ts
-function verifyRequestOrigin(method: string, originHeader: string): boolean {
+function verifyRequestOrigin(method: string, originHeader: string | null): boolean {
 	if (method === "GET" || method === "HEAD") {
 		return true;
 	}
-	return originHeader === "example.com";
+	if (originHeader === null) {
+		return false;
+	}
+	return new URL(originHeader).host === "example.com";
 }
 
 // Enable strict origin check only on production environments.
-function verifyRequestOrigin(method: string, originHeader: string): boolean {
+function verifyRequestOrigin(method: string, originHeader: string | null): boolean {
 	if (env !== ENV.PROD) {
 		return true;
 	}
 	if (method === "GET" || method === "HEAD") {
 		return true;
 	}
-	return originHeader === "example.com";
+	if (originHeader === null) {
+		return false;
+	}
+	return new URL(originHeader).host === "example.com";
 }
 ```
 


### PR DESCRIPTION
## Summary

- The CSRF protection example in `pages/sessions/basic.md` compares the raw `Origin` header (a full URL like `"https://example.com"`) against a bare domain `"example.com"`. This comparison always fails, meaning users following the docs implement CSRF protection that silently rejects every non-GET/HEAD request.
- Fix: parse the `Origin` header with `new URL(originHeader).host` to extract the host before comparing.
- Also adds an explicit `null` check for the `Origin` header (with updated type signature) and returns `false` when it's missing, consistent with the prose above the example which says "Requests without the Origin header should be blocked."

## Before (broken)

```ts
return originHeader === "example.com";
// originHeader is "https://example.com" → always false
```

## After (fixed)

```ts
if (originHeader === null) {
    return false;
}
return new URL(originHeader).host === "example.com";
// new URL("https://example.com").host → "example.com" → correct match
```

## Test plan

- [ ] Verify that `new URL("https://example.com").host` returns `"example.com"` (it does per the URL spec)
- [ ] Confirm no other docs files contain the same broken pattern (checked — only `pages/sessions/basic.md` is affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)